### PR TITLE
Elt

### DIFF
--- a/massiv/src/Data/Array/Massiv/Stencil.hs
+++ b/massiv/src/Data/Array/Massiv/Stencil.hs
@@ -11,7 +11,7 @@
 --
 module Data.Array.Massiv.Stencil
   ( Stencil
-  , Elt
+  , Identity
   , makeStencil
   , mkConvolutionStencil
   , mkConvolutionStencilFromKernel
@@ -28,6 +28,7 @@ import           Data.Array.Massiv.Manifest
 import           Data.Array.Massiv.Stencil.Internal
 import           Data.Array.Massiv.Stencil.Convolution
 import           Data.Default                       (Default (def))
+import           Data.Functor.Identity
 import           GHC.Exts                           (inline)
 
 
@@ -36,11 +37,11 @@ mapStencil :: (Source r ix e, Manifest r ix e) =>
               Stencil ix e a -> Array r ix e -> Array WD ix a
 mapStencil (Stencil b sSz sCenter stencilF) !arr =
   WDArray
-    (DArray (getComp arr) sz (unElt . stencilF (Elt . borderIndex b arr)))
+    (DArray (getComp arr) sz (runIdentity . stencilF (Identity . borderIndex b arr)))
     (Just sSz)
     sCenter
     (liftIndex2 (-) sz (liftIndex2 (-) sSz oneIndex))
-    (unElt . stencilF (Elt . unsafeIndex arr))
+    (runIdentity . stencilF (Identity . unsafeIndex arr))
   where
     !sz = size arr
 {-# INLINE mapStencil #-}
@@ -88,7 +89,7 @@ makeStencil
   => Border e -- ^ Border resolution technique
   -> ix -- ^ Size of the stencil
   -> ix -- ^ Center of the stencil
-  -> ((ix -> Elt e) -> Elt a) -- ^ Stencil function that receives another function as
+  -> ((ix -> Identity e) -> Identity a) -- ^ Stencil function that receives another function as
                       -- it's argument that can index elements of the source
                       -- array with respect to the center of the stencil.
   -> Stencil ix e a

--- a/massiv/src/Data/Array/Massiv/Stencil/Internal.hs
+++ b/massiv/src/Data/Array/Massiv/Stencil/Internal.hs
@@ -25,6 +25,7 @@ import           Data.Array.Massiv.Common
 import           Data.Array.Massiv.Delayed
 import           Data.Array.Massiv.Manifest
 import           Data.Default                (Default (def))
+import           Data.Functor.Identity
 import           GHC.Exts                    (inline)
 
 import qualified Data.Vector.Unboxed         as VU
@@ -35,85 +36,11 @@ data Stencil ix e a = Stencil
   { stencilBorder :: Border e
   , stencilSize   :: !ix
   , stencilCenter :: !ix
-  , stencilFunc   :: (ix -> Elt e) -> ix -> Elt a
+  , stencilFunc   :: (ix -> Identity e) -> ix -> Identity a
   }
 
 instance (NFData e, Index ix) => NFData (Stencil ix e a) where
   rnf (Stencil b sz ix f) = rnf b `seq` rnf sz `seq` rnf ix `seq` f `seq` ()
-
-
-newtype Elt e = Elt { unElt :: e }
-
-instance Functor Elt where
-  fmap f (Elt e) = Elt (f e)
-  {-# INLINE fmap #-}
-
-instance Applicative Elt where
-  pure = Elt
-  {-# INLINE pure #-}
-  (<*>) (Elt f) (Elt e) = Elt (f e)
-  {-# INLINE (<*>) #-}
-
-instance Num e => Num (Elt e) where
-  (+) = liftA2 (+)
-  {-# INLINE (+) #-}
-  (*) = liftA2 (*)
-  {-# INLINE (*) #-}
-  negate = fmap negate
-  {-# INLINE negate #-}
-  abs = fmap abs
-  {-# INLINE abs #-}
-  signum = fmap signum
-  {-# INLINE signum #-}
-  fromInteger = Elt . fromInteger
-  {-# INLINE fromInteger #-}
-
-instance Fractional e => Fractional (Elt e) where
-  (/) = liftA2 (/)
-  {-# INLINE (/) #-}
-  recip = fmap recip
-  {-# INLINE recip #-}
-  fromRational = pure . fromRational
-  {-# INLINE fromRational #-}
-
-instance Floating e => Floating (Elt e) where
-  pi = pure pi
-  {-# INLINE pi #-}
-  exp = fmap exp
-  {-# INLINE exp #-}
-  log = fmap log
-  {-# INLINE log #-}
-  sqrt = fmap sqrt
-  {-# INLINE sqrt #-}
-  (**) = liftA2 (**)
-  {-# INLINE (**) #-}
-  logBase = liftA2 logBase
-  {-# INLINE logBase #-}
-  sin = fmap sin
-  {-# INLINE sin #-}
-  cos = fmap cos
-  {-# INLINE cos #-}
-  tan = fmap tan
-  {-# INLINE tan #-}
-  asin = fmap asin
-  {-# INLINE asin #-}
-  acos = fmap acos
-  {-# INLINE acos #-}
-  atan = fmap atan
-  {-# INLINE atan #-}
-  sinh = fmap sinh
-  {-# INLINE sinh #-}
-  cosh = fmap cosh
-  {-# INLINE cosh #-}
-  tanh = fmap tanh
-  {-# INLINE tanh #-}
-  asinh = fmap asinh
-  {-# INLINE asinh #-}
-  acosh = fmap acosh
-  {-# INLINE acosh #-}
-  atanh = fmap atanh
-  {-# INLINE atanh #-}
-
 
 data Dependency ix = Dependency { depDimension :: Int
                                 , depDirection :: Int }
@@ -183,7 +110,7 @@ makeStencilM b !sSz !sCenter relStencil =
 instance Functor (Stencil ix e) where
   fmap f stencil@(Stencil {stencilFunc = g}) = stencil {stencilFunc = stF}
     where
-      stF s = Elt . f . unElt . g s
+      stF s = Identity . f . runIdentity . g s
       {-# INLINE stF #-}
   {-# INLINE fmap #-}
 
@@ -195,12 +122,12 @@ instance Functor (Stencil ix e) where
 -- Stencil - both stencils are trusted, increasing the size will not affect the
 -- safety.
 instance (Default e, Index ix) => Applicative (Stencil ix e) where
-  pure a = Stencil Edge oneIndex zeroIndex (const (const (Elt a)))
+  pure a = Stencil Edge oneIndex zeroIndex (const (const (Identity a)))
   {-# INLINE pure #-}
   (<*>) (Stencil _ sSz1 sC1 f1) (Stencil sB sSz2 sC2 f2) =
     validateStencil def (Stencil sB newSz maxCenter stF)
     where
-      stF gV !ix = Elt ((unElt (f1 gV ix)) (unElt (f2 gV ix)))
+      stF gV !ix = Identity ((runIdentity (f1 gV ix)) (runIdentity (f2 gV ix)))
       {-# INLINE stF #-}
       !newSz =
         liftIndex2
@@ -287,6 +214,6 @@ validateStencil
   => e -> Stencil ix e a -> Stencil ix e a
 validateStencil d s@(Stencil _ sSz sCenter stencil) =
   let valArr = DArray Seq sSz (const d)
-  in stencil (Elt . safeStencilIndex valArr) sCenter `seq` s
+  in stencil (Identity . safeStencilIndex valArr) sCenter `seq` s
 {-# INLINE validateStencil #-}
 


### PR DESCRIPTION
This changes the Stencil functor for `Identity` (which has all the `Fractional`, `Num`, ... instances already) (80011cf) and only uses the applicative functor in `makeStencil`: basically the user has full power when creating a `Stencil` with `Stencil` but has better safety guarantees in `makeStencil`. Using the `forall f` ensures that the user can never extract a value from `f` (even with `Elt`, the user could import the extractor).

Another solution would be to have the `forall f.` in the `stencilFunc`. 
