### PR TITLE
Provide Ord instances for Array

### DIFF
--- a/massiv/src/Data/Massiv/Array/Manifest/BoxedNF.hs
+++ b/massiv/src/Data/Massiv/Array/Manifest/BoxedNF.hs
@@ -25,7 +25,7 @@ module Data.Massiv.Array.Manifest.BoxedNF
 
 import           Control.DeepSeq                     (NFData (..), deepseq)
 import           Control.Monad.ST                    (runST)
-import           Data.Massiv.Array.Delayed.Internal  (eq)
+import           Data.Massiv.Array.Delayed.Internal  (eq, ord)
 import           Data.Massiv.Array.Manifest.Internal (M, toManifest)
 import           Data.Massiv.Array.Manifest.List     as A
 import           Data.Massiv.Array.Mutable
@@ -63,6 +63,10 @@ instance (Index ix, NFData e) => NFData (Array N ix e) where
 instance (Index ix, NFData e, Eq e) => Eq (Array N ix e) where
   (==) = eq (==)
   {-# INLINE (==) #-}
+
+instance (Index ix, NFData e, Ord e) => Ord (Array N ix e) where
+  compare = ord compare
+  {-# INLINE compare #-}
 
 
 instance (Index ix, NFData e) => Construct N ix e where

--- a/massiv/src/Data/Massiv/Array/Manifest/BoxedStrict.hs
+++ b/massiv/src/Data/Massiv/Array/Manifest/BoxedStrict.hs
@@ -20,7 +20,7 @@ module Data.Massiv.Array.Manifest.BoxedStrict
 
 import           Control.DeepSeq                     (NFData (..))
 import qualified Data.Foldable                       as F (Foldable (..))
-import           Data.Massiv.Array.Delayed.Internal  (eq)
+import           Data.Massiv.Array.Delayed.Internal  (eq, ord)
 import           Data.Massiv.Array.Manifest.BoxedNF  (deepseqArray,
                                                       deepseqArrayP)
 import           Data.Massiv.Array.Unsafe            (unsafeGenerateArray,
@@ -57,6 +57,10 @@ instance (Index ix, NFData e) => NFData (Array B ix e) where
 instance (Index ix, Eq e) => Eq (Array B ix e) where
   (==) = eq (==)
   {-# INLINE (==) #-}
+
+instance (Index ix, Ord e) => Ord (Array B ix e) where
+  compare = ord compare
+  {-# INLINE compare #-}
 
 instance Index ix => Construct B ix e where
   getComp = bComp

--- a/massiv/src/Data/Massiv/Array/Manifest/Primitive.hs
+++ b/massiv/src/Data/Massiv/Array/Manifest/Primitive.hs
@@ -22,7 +22,7 @@ module Data.Massiv.Array.Manifest.Primitive
 
 import           Control.DeepSeq                     (NFData (..), deepseq)
 import           Control.Monad.ST                    (runST)
-import           Data.Massiv.Array.Delayed.Internal  (eq)
+import           Data.Massiv.Array.Delayed.Internal  (eq, ord)
 import           Data.Massiv.Array.Manifest.Internal
 import           Data.Massiv.Array.Manifest.List     as A
 import           Data.Massiv.Array.Mutable
@@ -55,6 +55,9 @@ instance (Prim e, Eq e, Index ix) => Eq (Array P ix e) where
   (==) = eq (==)
   {-# INLINE (==) #-}
 
+instance (Prim e, Ord e, Index ix) => Ord (Array P ix e) where
+  compare = ord compare
+  {-# INLINE compare #-}
 
 instance (Prim e, Index ix) => Construct P ix e where
   getComp = pComp

--- a/massiv/src/Data/Massiv/Array/Manifest/Storable.hs
+++ b/massiv/src/Data/Massiv/Array/Manifest/Storable.hs
@@ -20,7 +20,7 @@ module Data.Massiv.Array.Manifest.Storable
   ) where
 
 import           Control.DeepSeq                     (NFData (..), deepseq)
-import           Data.Massiv.Array.Delayed.Internal  (eq)
+import           Data.Massiv.Array.Delayed.Internal  (eq, ord)
 import           Data.Massiv.Array.Manifest.Internal
 import           Data.Massiv.Array.Manifest.List     as A
 import           Data.Massiv.Array.Mutable
@@ -49,6 +49,10 @@ instance (Index ix, NFData e) => NFData (Array S ix e) where
 instance (VS.Storable e, Eq e, Index ix) => Eq (Array S ix e) where
   (==) = eq (==)
   {-# INLINE (==) #-}
+
+instance (VS.Storable e, Ord e, Index ix) => Ord (Array S ix e) where
+  compare = ord compare
+  {-# INLINE compare #-}
 
 instance (VS.Storable e, Index ix) => Construct S ix e where
   getComp = sComp

--- a/massiv/src/Data/Massiv/Array/Manifest/Unboxed.hs
+++ b/massiv/src/Data/Massiv/Array/Manifest/Unboxed.hs
@@ -20,7 +20,7 @@ module Data.Massiv.Array.Manifest.Unboxed
   ) where
 
 import           Control.DeepSeq                     (NFData (..), deepseq)
-import           Data.Massiv.Array.Delayed.Internal  (eq)
+import           Data.Massiv.Array.Delayed.Internal  (eq, ord)
 import           Data.Massiv.Array.Manifest.Internal (M, toManifest)
 import           Data.Massiv.Array.Manifest.List     as A
 import           Data.Massiv.Array.Mutable
@@ -63,6 +63,10 @@ instance (VU.Unbox e, Index ix) => Construct U ix e where
 instance (VU.Unbox e, Eq e, Index ix) => Eq (Array U ix e) where
   (==) = eq (==)
   {-# INLINE (==) #-}
+
+instance (VU.Unbox e, Ord e, Index ix) => Ord (Array U ix e) where
+  compare = ord compare
+  {-# INLINE compare #-}
 
 
 instance (VU.Unbox e, Index ix) => Source U ix e where


### PR DESCRIPTION
These instances might be a bit controversial since it is not clear how the ordering should work for multi-dimensional arrays. However, we use `Ord` in Haskell quite often as an implementation technique where we only care about being able to order elements in some way but do not care about the specific ordering, e.g. `Data.Map`, `ordNub`, …. So instead of trying to define a specific ordering I’ve just mentioned in the docs that this should only be used for `Data.Map` like usecases.