### PR TITLE
More typeclass instances for `Value`

### DIFF
--- a/massiv/massiv.cabal
+++ b/massiv/massiv.cabal
@@ -57,6 +57,10 @@ library
                      , ghc-prim
                      , primitive
                      , vector
+
+  if impl(ghc < 8.0)
+    build-depends: semigroups
+
   default-language:    Haskell2010
   ghc-options:         -Wall
 

--- a/massiv/src/Data/Massiv/Array/Stencil/Internal.hs
+++ b/massiv/src/Data/Massiv/Array/Stencil/Internal.hs
@@ -49,20 +49,6 @@ instance Applicative Value where
   (<*>) (Value f) (Value e) = Value (f e)
   {-# INLINE (<*>) #-}
 
-instance Monad Value where
-  return = pure
-  {-# INLINE return #-}
-  (Value a) >>= f = f a
-  {-# INLINE (>>=) #-}
-
-instance Foldable Value where
-  foldMap f (Value a) = f a
-  {-# INLINE foldMap #-}
-
-instance Traversable Value where
-  traverse f (Value a) = fmap Value (f a)
-  {-# INLINE traverse #-}
-
 instance Semigroup a => Semigroup (Value a) where
   Value a <> Value b = Value (a <> b)
   {-# INLINE (<>) #-}


### PR DESCRIPTION
Turns out I needed these (well, at least `Monad`). Is there any performance reason why `Value` shouldn't be a `Monad`?