### PR TITLE
added ColorSpace to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ what is actually going on, so let's expend on it:
 
 ```haskell
 import Data.Massiv.Array.IO
+import Graphics.ColorSpace
 
 main :: IO ()
 main = do


### PR DESCRIPTION
The example doesn't work without the `Graphics.ColorSpace` import, `PixelY` comes from there.