### PR TITLE
Added 2d convolutions with stride

### DIFF
--- a/massiv/src/Data/Massiv/Array/Stencil.hs
+++ b/massiv/src/Data/Massiv/Array/Stencil.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RecordWildCards       #-}
 -- |
 -- Module      : Data.Massiv.Array.Stencil
 -- Copyright   : (c) Alexey Kuleshevich 2018
@@ -15,6 +16,7 @@ module Data.Massiv.Array.Stencil
   , Value
   , mapStencil
   , makeStencil
+  , strideMapStencil2
   -- * Convolution
   , module Data.Massiv.Array.Stencil.Convolution
   ) where
@@ -47,6 +49,32 @@ mapStencil b (Stencil sSz sCenter stencilF) !arr =
     !sz = size arr
 {-# INLINE mapStencil #-}
 
+strideMapStencil2 ::
+       (Source r Ix2 e, Manifest r Ix2 e)
+    => Int -- ^ Stride
+    -> Border e -- ^ Border resolution technique
+    -> Stencil Ix2 e a -- ^ Stencil to map over the array
+    -> Array r Ix2 e -- ^ Source array
+    -> Array DW Ix2 a
+strideMapStencil2 stride b stencil arr =
+    let newArr@DWArray {..} = mapStencil b stencil arr
+    in newArr
+        { wdArray = wdArray
+            { dSize = liftIndex divStride $ dSize wdArray
+            , dUnsafeIndex = dUnsafeIndex wdArray . indexMap
+            }
+        , wdWindowStartIndex = ceilingDivStride2d wdWindowSize
+        , wdWindowSize = ceilingDivStride2d (wdWindowSize + wdWindowStartIndex) - wdWindowStartIndex
+        , wdWindowUnsafeIndex = wdWindowUnsafeIndex . indexMap
+        }
+  where
+    ceilingDivStride a =
+        let a' = fromIntegral a :: Double
+            stride' = fromIntegral stride
+        in ceiling $ a' / stride'
+    ceilingDivStride2d = liftIndex $ ceilingDivStride
+    divStride x = x `div` stride
+    indexMap = liftIndex (* stride)
 
 -- | Construct a stencil from a function, which describes how to calculate the
 -- value at a point while having access to neighboring elements with a function

--- a/massiv/src/Data/Massiv/Array/Stencil/Convolution.hs
+++ b/massiv/src/Data/Massiv/Array/Stencil/Convolution.hs
@@ -27,8 +27,8 @@ import           GHC.Exts                           (inline)
 --
 -- Here is how to create a 2D horizontal Sobel Stencil:
 --
--- > sobelX :: Num e => Border e -> Stencil Ix2 e e
--- > sobelX b = makeConvolutionStencil b (3 :. 3) (1 :. 1) $
+-- > sobelX :: Num e => Stencil Ix2 e e
+-- > sobelX = makeConvolutionStencil (3 :. 3) (1 :. 1) $
 -- >            \f -> f (-1 :. -1) 1 . f (-1 :. 1) (-1) .
 -- >                  f ( 0 :. -1) 2 . f ( 0 :. 1) (-2) .
 -- >                  f ( 1 :. -1) 1 . f ( 1 :. 1) (-1)

--- a/massiv/tests/Data/Massiv/Array/StencilSpec.hs
+++ b/massiv/tests/Data/Massiv/Array/StencilSpec.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MonoLocalBinds        #-}
-{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedLists       #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 module Data.Massiv.Array.StencilSpec (spec) where
 
@@ -15,7 +15,7 @@ import           Test.QuickCheck
 import           Test.QuickCheck.Function
 import           Data.Default              (Default(def))
 -- sum3x3Stencil :: Fractional a => Stencil Ix2 a a
--- sum3x3Stencil = mkConvolutionStencil (3 :. 3) (1 :. 1) $ \ get ->
+-- sum3x3Stencil = makeConvolutionStencil (3 :. 3) (1 :. 1) $ \ get ->
 --   get (-1 :. -1) 1 . get (-1 :. 0) 1 . get (-1 :. 1) 1 .
 --   get ( 0 :. -1) 1 . get ( 0 :. 0) 1 . get ( 0 :. 1) 1 .
 --   get ( 1 :. -1) 1 . get ( 1 :. 0) 1 . get ( 1 :. 1) 1
@@ -77,7 +77,7 @@ stencilDirection ix = computeAs U . mapStencil (Fill def) (makeStencil (3 :. 3) 
 
 
 stencilCorners ::
-     (Default a, Unbox a, Manifest r Ix2 a) => Ix2 -> Ix2 -> Array r Ix2 a -> Array U Ix2 a
+      (Default a, Unbox a, Manifest r Ix2 a) => Ix2 -> Ix2 -> Array r Ix2 a -> Array U Ix2 a
 stencilCorners ixC ix = computeAs U . mapStencil (Fill def) (makeStencil (3 :. 3) ixC $ \f -> f ix)
 
 spec :: Spec
@@ -102,3 +102,23 @@ spec = do
         stencilCorners (2 :. 2) (-2 :. -2) arr `shouldBe` [[0, 0, 0], [0, 0, 0], [0, 0, 1]]
       it "Direction Left/Bottom Corner" $
         stencilCorners (2 :. 0) (-2 :. 2) arr `shouldBe` [[0, 0, 0], [0, 0, 0], [3, 0, 0]]
+      describe "strideMapStencil2" $ do
+        it "small array" $
+          let kernel =
+                  [[-1, 0, 1], [0, 1, 0], [-1, 0, 1]] :: Array U Ix2 Int
+              stencil = makeConvolutionStencilFromKernel kernel
+              stride = 2
+              strideArr =
+                  strideMapStencil2 stride (Fill 0) stencil arr
+           in computeAs U strideArr `shouldBe` [[-4]]
+        it "larger array" $
+          let kernel =
+                  [[-1, 0, 1], [0, 1, 0], [-1, 0, 1]] :: Array U Ix2 Int
+              stencil = makeConvolutionStencilFromKernel kernel
+              stride = 2
+              largeArr = fromLists' Par
+                  [ [5*n + 1 .. 5 * (n + 1)] | n <- [0..4]]
+                    :: Array U Ix2 Int
+              strideArr =
+                  strideMapStencil2 stride (Fill 0) stencil largeArr
+           in computeAs U strideArr `shouldBe` [[-6, 1], [-13, 9]]


### PR DESCRIPTION
This means that you map a convolution/stencil over an array,
and take out the elements
(0,0), (0,n), (0,2n) ..
(n,0), (n,n), (n,2n) ..
..
This is necessary to implement convolutional layers for neural networks.