### PR TITLE
Added massiv-test-utils

### DIFF
--- a/massiv-examples/stack.yaml
+++ b/massiv-examples/stack.yaml
@@ -3,7 +3,8 @@ packages:
 - '.'
 - '../massiv/'
 - '../massiv-io/'
-extra-deps: []
+extra-deps:
+- validity-0.6.0.0
 flags: {}
 extra-package-dbs: []
 nix:

--- a/massiv-io/stack-ghc-8.2.yaml
+++ b/massiv-io/stack-ghc-8.2.yaml
@@ -2,6 +2,7 @@ resolver: lts-10.0
 packages:
 - '.'
 - '../massiv/'
-extra-deps: []
+extra-deps:
+- validity-0.7.0.0
 flags: {}
 extra-package-dbs: []

--- a/massiv-io/stack.yaml
+++ b/massiv-io/stack.yaml
@@ -2,6 +2,9 @@ resolver: lts-9.20
 packages:
 - '.'
 - '../massiv/'
-extra-deps: []
+extra-deps:
+- validity-0.6.0.0
 flags: {}
 extra-package-dbs: []
+nix:
+  packages: [ zlib ]

--- a/massiv-test-utils/.gitignore
+++ b/massiv-test-utils/.gitignore
@@ -1,0 +1,3 @@
+.stack-work/
+massiv-test-utils.cabal
+*~

--- a/massiv-test-utils/ChangeLog.md
+++ b/massiv-test-utils/ChangeLog.md
@@ -1,0 +1,3 @@
+# Changelog for massiv-test-utils
+
+## Unreleased changes

--- a/massiv-test-utils/LICENSE
+++ b/massiv-test-utils/LICENSE
@@ -1,0 +1,30 @@
+Copyright Nick Van den Broeck (c) 2018
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Nick Van den Broeck nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/massiv-test-utils/README.md
+++ b/massiv-test-utils/README.md
@@ -1,0 +1,1 @@
+# massiv-test-utils

--- a/massiv-test-utils/Setup.hs
+++ b/massiv-test-utils/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/massiv-test-utils/massiv-test-utils.cabal
+++ b/massiv-test-utils/massiv-test-utils.cabal
@@ -1,0 +1,42 @@
+-- This file has been generated from package.yaml by hpack version 0.21.2.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 9d28c80fa6eb0dfcb3a0185001be5547a63f37a684888872c445c28bbe35a4e2
+
+name:           massiv-test-utils
+version:        0.1.0.0
+homepage:       https://github.com/lehins/massiv-test-utils#readme
+bug-reports:    https://github.com/lehins/massiv-test-utils/issues
+author:         Nick Van den Broeck
+maintainer:     alexey@kuleshevi.ch
+copyright:      2018 Nick Van den Broeck
+license:        BSD3
+license-file:   LICENSE
+build-type:     Simple
+cabal-version:  >= 1.10
+
+source-repository head
+  type: git
+  location: https://github.com/lehins/massiv-test-utils
+
+library
+  exposed-modules:
+      Test.Massiv
+      Test.Massiv.Core
+      Test.Massiv.Core.Computation
+      Test.Massiv.Core.Index
+      Test.Massiv.Core.Index.Ix
+  other-modules:
+      Import
+  hs-source-dirs:
+      src
+  default-extensions: NoImplicitPrelude
+  ghc-options: -Wall
+  build-depends:
+      QuickCheck
+    , base >=4.7 && <5
+    , genvalidity >=0.4.0.4
+    , genvalidity-hspec >=0.5
+    , massiv >=0.2
+  default-language: Haskell2010

--- a/massiv-test-utils/massiv-test-utils.cabal
+++ b/massiv-test-utils/massiv-test-utils.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9d28c80fa6eb0dfcb3a0185001be5547a63f37a684888872c445c28bbe35a4e2
+-- hash: b20fc0afde86ac49e752e18bdd58f17643f920ea7f010600d94dba9b8792186f
 
 name:           massiv-test-utils
 version:        0.1.0.0
@@ -39,4 +39,5 @@ library
     , genvalidity >=0.4.0.4
     , genvalidity-hspec >=0.5
     , massiv >=0.2
+    , validity-massiv
   default-language: Haskell2010

--- a/massiv-test-utils/package.yaml
+++ b/massiv-test-utils/package.yaml
@@ -12,6 +12,7 @@ dependencies:
 - genvalidity-hspec >= 0.5
 - massiv >= 0.2
 - QuickCheck
+- validity-massiv
 
 library:
   source-dirs: src

--- a/massiv-test-utils/package.yaml
+++ b/massiv-test-utils/package.yaml
@@ -1,0 +1,28 @@
+name:                massiv-test-utils
+version:             0.1.0.0
+github:              "lehins/massiv-test-utils"
+license:             BSD3
+author:              "Nick Van den Broeck"
+maintainer:          "alexey@kuleshevi.ch"
+copyright:           "2018 Nick Van den Broeck"
+
+dependencies:
+- base >= 4.7 && < 5
+- genvalidity >= 0.4.0.4
+- genvalidity-hspec >= 0.5
+- massiv >= 0.2
+- QuickCheck
+
+library:
+  source-dirs: src
+  ghc-options: -Wall
+  default-extensions:
+  - NoImplicitPrelude
+  exposed-modules:
+  - Test.Massiv
+  - Test.Massiv.Core
+  - Test.Massiv.Core.Computation
+  - Test.Massiv.Core.Index
+  - Test.Massiv.Core.Index.Ix
+  other-modules:
+  - Import

--- a/massiv-test-utils/src/Import.hs
+++ b/massiv-test-utils/src/Import.hs
@@ -1,0 +1,9 @@
+module Import
+    ( module X
+    ) where
+
+import Prelude as X
+
+import Data.GenValidity as X
+
+import GHC.TypeLits as X

--- a/massiv-test-utils/src/Test/Massiv.hs
+++ b/massiv-test-utils/src/Test/Massiv.hs
@@ -1,0 +1,5 @@
+module Test.Massiv
+    ( module Test.Massiv.Core
+    ) where
+
+import Test.Massiv.Core

--- a/massiv-test-utils/src/Test/Massiv/Core.hs
+++ b/massiv-test-utils/src/Test/Massiv/Core.hs
@@ -1,0 +1,7 @@
+module Test.Massiv.Core
+    ( module Test.Massiv.Core.Computation
+    , module Test.Massiv.Core.Index
+    ) where
+
+import Test.Massiv.Core.Computation
+import Test.Massiv.Core.Index

--- a/massiv-test-utils/src/Test/Massiv/Core/Computation.hs
+++ b/massiv-test-utils/src/Test/Massiv/Core/Computation.hs
@@ -1,0 +1,13 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Test.Massiv.Core.Computation where
+
+import Import
+
+import Test.QuickCheck
+
+import Data.Massiv.Core
+
+instance GenUnchecked Comp
+
+instance GenValid Comp

--- a/massiv-test-utils/src/Test/Massiv/Core/Index.hs
+++ b/massiv-test-utils/src/Test/Massiv/Core/Index.hs
@@ -1,0 +1,5 @@
+module Test.Massiv.Core.Index
+    ( module Test.Massiv.Core.Index.Ix
+    ) where
+
+import Test.Massiv.Core.Index.Ix

--- a/massiv-test-utils/src/Test/Massiv/Core/Index/Ix.hs
+++ b/massiv-test-utils/src/Test/Massiv/Core/Index/Ix.hs
@@ -1,0 +1,36 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Test.Massiv.Core.Index.Ix where
+
+import Import
+
+import Data.Massiv.Core
+
+intToList :: Int -> [Int]
+intToList x =
+    if x >= 0
+        then [0 .. x - 1]
+        else reverse [x + 1 .. 0]
+
+instance GenUnchecked Ix0
+
+instance GenValid Ix0
+
+instance GenUnchecked Ix2 where
+    genUnchecked = (:.) <$> genUnchecked <*> genUnchecked
+    shrinkUnchecked (a :. b) = [i :. j | i <- intToList a, j <- intToList b]
+
+instance GenValid Ix2 where
+    genValid = (:.) <$> genValid <*> genValid
+
+instance GenUnchecked (Ix (n - 1)) => GenUnchecked (IxN n) where
+    genUnchecked = (:>) <$> genUnchecked <*> genUnchecked
+    shrinkUnchecked (a :> b) =
+        [i :> j | i <- intToList a, j <- shrinkUnchecked b]
+
+instance GenValid (Ix (n - 1)) => GenValid (IxN n) where
+    genValid = (:>) <$> genValid <*> genValid

--- a/massiv-test-utils/stack.yaml
+++ b/massiv-test-utils/stack.yaml
@@ -2,10 +2,11 @@ resolver: lts-9.20
 packages:
 - '.'
 - '../massiv'
+- '../validity-massiv'
 extra-deps:
 - genvalidity-0.5.0.3
 - genvalidity-hspec-0.6.0.3
 - genvalidity-property-0.2.0.2
 - QuickCheck-2.11.1
-- validity-0.6.0.0
+- validity-0.7.0.0
 flags: {}

--- a/massiv-test-utils/stack.yaml
+++ b/massiv-test-utils/stack.yaml
@@ -1,0 +1,11 @@
+resolver: lts-9.20
+packages:
+- '.'
+- '../massiv'
+extra-deps:
+- genvalidity-0.5.0.3
+- genvalidity-hspec-0.6.0.3
+- genvalidity-property-0.2.0.2
+- QuickCheck-2.11.1
+- validity-0.6.0.0
+flags: {}

--- a/massiv/massiv.cabal
+++ b/massiv/massiv.cabal
@@ -63,6 +63,7 @@ library
                      , deepseq
                      , ghc-prim
                      , primitive
+                     , validity >= 0.6
                      , vector
   include-dirs: include
   install-includes: massiv.h

--- a/massiv/src/Data/Massiv/Array/Delayed/Interleaved.hs
+++ b/massiv/src/Data/Massiv/Array/Delayed/Interleaved.hs
@@ -32,7 +32,7 @@ data DI = DI deriving (Generic)
 
 type instance EltRepr DI ix = DI
 
-newtype instance Array DI ix e = DIArray { idArray :: (Array D ix e) } deriving (Generic)
+newtype instance Array DI ix e = DIArray { diArray :: (Array D ix e) } deriving (Generic)
 
 instance Index ix => Construct DI ix e where
   getComp = dComp . diArray

--- a/massiv/src/Data/Massiv/Array/Delayed/Interleaved.hs
+++ b/massiv/src/Data/Massiv/Array/Delayed/Interleaved.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE DeriveGeneric         #-}
 -- |
 -- Module      : Data.Massiv.Array.Delayed.Interleaved
 -- Copyright   : (c) Alexey Kuleshevich 2018
@@ -21,15 +23,16 @@ module Data.Massiv.Array.Delayed.Interleaved
 import           Data.Massiv.Array.Delayed.Internal
 import           Data.Massiv.Core.Common
 import           Data.Massiv.Core.Scheduler
+import           GHC.Generics (Generic)
 
 
 -- | Delayed array that will be loaded in an interleaved fasion during parallel
 -- computation.
-data DI = DI
+data DI = DI deriving (Generic)
 
 type instance EltRepr DI ix = DI
 
-newtype instance Array DI ix e = DIArray { diArray :: Array D ix e }
+newtype instance Array DI ix e = DIArray { idArray :: (Array D ix e) } deriving (Generic)
 
 instance Index ix => Construct DI ix e where
   getComp = dComp . diArray

--- a/massiv/src/Data/Massiv/Array/Delayed/Internal.hs
+++ b/massiv/src/Data/Massiv/Array/Delayed/Internal.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE DeriveGeneric         #-}
 -- |
 -- Module      : Data.Massiv.Array.Delayed.Internal
 -- Copyright   : (c) Alexey Kuleshevich 2018
@@ -28,19 +30,20 @@ import           Data.Foldable                       (Foldable (..))
 import           Data.Massiv.Array.Ops.Fold.Internal as A
 import           Data.Massiv.Core.Common
 import           Data.Massiv.Core.Scheduler
-import           Data.Monoid                         ((<>))
-import           GHC.Base                            (build)
-import           Prelude                             hiding (zipWith)
-
 #include "massiv.h"
+import           Data.Monoid                ((<>))
+import           GHC.Base                   (build)
+import           GHC.Generics (Generic)
+import           Prelude                    hiding (zipWith)
 
 -- | Delayed representation.
-data D = D deriving Show
+data D = D deriving (Show, Generic)
 
 
 data instance Array D ix e = DArray { dComp :: !Comp
                                     , dSize :: !ix
                                     , dUnsafeIndex :: ix -> e }
+
 type instance EltRepr D ix = D
 
 instance Index ix => Construct D ix e where

--- a/massiv/src/Data/Massiv/Array/Delayed/Windowed.hs
+++ b/massiv/src/Data/Massiv/Array/Delayed/Windowed.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE DeriveGeneric         #-}
 -- |
 -- Module      : Data.Massiv.Array.Delayed.Windowed
 -- Copyright   : (c) Alexey Kuleshevich 2018
@@ -30,9 +31,10 @@ import           Data.Massiv.Core.List                  (showArray)
 import           Data.Massiv.Core.Scheduler
 import           Data.Proxy                             (Proxy (..))
 import           Data.Typeable                          (showsTypeRep, typeRep)
+import           GHC.Generics hiding (D)
 
 -- | Delayed Windowed Array representation.
-data DW = DW
+data DW = DW deriving Generic
 
 type instance EltRepr DW ix = D
 
@@ -43,8 +45,7 @@ data instance Array DW ix e = DWArray { wdArray :: !(Array D ix e)
                                         -- while computing an array
                                       , wdWindowStartIndex :: !ix
                                       , wdWindowSize :: !ix
-                                      , wdWindowUnsafeIndex :: ix -> e }
-
+                                      , wdWindowUnsafeIndex :: ix -> e } deriving Generic
 
 instance {-# OVERLAPPING #-} (Show e, Ragged L ix e, Load DW ix e) =>
   Show (Array DW ix e) where

--- a/massiv/src/Data/Massiv/Array/Manifest/Boxed.hs
+++ b/massiv/src/Data/Massiv/Array/Manifest/Boxed.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE ScopedTypeVariables       #-}
 {-# LANGUAGE TypeFamilies              #-}
 {-# LANGUAGE UndecidableInstances      #-}
+{-# LANGUAGE DeriveGeneric             #-}
 -- |
 -- Module      : Data.Massiv.Array.Manifest.Boxed
 -- Copyright   : (c) Alexey Kuleshevich 2018
@@ -58,6 +59,7 @@ import           GHC.Base                            (build)
 import           GHC.Exts                            as GHC (IsList (..))
 import           GHC.Prim
 import           GHC.Types
+import           GHC.Generics
 import           Prelude                             hiding (mapM)
 
 #include "massiv.h"
@@ -78,7 +80,7 @@ sizeofMutableArray (A.MutableArray ma#) = I# (sizeofMutableArray# ma#)
 
 -- | Array representation for Boxed elements. This structure is element and
 -- spine strict, but elements are strict to Weak Head Normal Form (WHNF) only.
-data B = B deriving Show
+data B = B deriving (Show, Generic)
 
 type instance EltRepr B ix = M
 

--- a/massiv/src/Data/Massiv/Array/Manifest/BoxedNF.hs
+++ b/massiv/src/Data/Massiv/Array/Manifest/BoxedNF.hs
@@ -1,0 +1,223 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE MagicHash             #-}
+{-# LANGUAGE BangPatterns          #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE DeriveGeneric         #-}
+-- |
+-- Module      : Data.Massiv.Array.Manifest.Boxed
+-- Copyright   : (c) Alexey Kuleshevich 2018
+-- License     : BSD3
+-- Maintainer  : Alexey Kuleshevich <lehins@yandex.ru>
+-- Stability   : experimental
+-- Portability : non-portable
+--
+module Data.Massiv.Array.Manifest.BoxedNF
+  ( N (..)
+  , Array(..)
+  , deepseqArray
+  , deepseqArrayP
+  , vectorFromArray
+  , vectorToArray
+  , castVectorToArray
+  ) where
+
+import           Control.DeepSeq                     (NFData (..), deepseq)
+import           Control.Monad.ST                    (runST)
+import           Data.Massiv.Array.Delayed.Internal  (eq, ord)
+import           Data.Massiv.Array.Manifest.Internal (M, toManifest)
+import           Data.Massiv.Array.Manifest.List     as A
+import           Data.Massiv.Array.Mutable
+import           Data.Massiv.Array.Unsafe            (unsafeGenerateArray,
+                                                      unsafeGenerateArrayP)
+import           Data.Massiv.Core.Common
+import           Data.Massiv.Core.List
+import           Data.Massiv.Core.Scheduler
+import qualified Data.Primitive.Array                as A
+import qualified Data.Vector                         as VB
+import qualified Data.Vector.Mutable                 as VB
+import           GHC.Exts                            as GHC (IsList (..))
+import           Prelude                             hiding (mapM)
+import           System.IO.Unsafe                    (unsafePerformIO)
+import           GHC.Generics (Generic)
+
+-- | Array representation for Boxed elements. This structure is element and
+-- spine strict, and elements are always in Normal Form (NF), therefore `NFData`
+-- instance is required.
+data N = N deriving (Show, Generic)
+
+type instance EltRepr N ix = M
+
+data instance Array N ix e = NArray { nComp :: Comp
+                                    , nSize :: !ix
+                                    , nData :: {-# UNPACK #-} !(A.Array e)
+                                    } deriving (Generic)
+
+instance (Index ix, NFData e) => NFData (Array N ix e) where
+  rnf (NArray comp sz arr) = -- comp `deepseq` sz `deepseq` a `seq` ()
+    case comp of
+      Seq        -> deepseqArray sz arr ()
+      ParOn wIds -> deepseqArrayP wIds sz arr ()
+
+
+instance (Index ix, NFData e, Eq e) => Eq (Array N ix e) where
+  (==) = eq (==)
+  {-# INLINE (==) #-}
+
+instance (Index ix, NFData e, Ord e) => Ord (Array N ix e) where
+  compare = ord compare
+  {-# INLINE compare #-}
+
+
+instance (Index ix, NFData e) => Construct N ix e where
+  getComp = nComp
+  {-# INLINE getComp #-}
+
+  setComp c arr = arr { nComp = c }
+  {-# INLINE setComp #-}
+
+  unsafeMakeArray Seq          !sz f = unsafeGenerateArray sz f
+  unsafeMakeArray (ParOn wIds) !sz f = unsafeGenerateArrayP wIds sz f
+  {-# INLINE unsafeMakeArray #-}
+
+instance (Index ix, NFData e) => Source N ix e where
+  unsafeLinearIndex (NArray _ _ a) = A.indexArray a
+  {-# INLINE unsafeLinearIndex #-}
+
+
+instance (Index ix, NFData e) => Size N ix e where
+  size = nSize
+  {-# INLINE size #-}
+
+  unsafeResize !sz !arr = arr { nSize = sz }
+  {-# INLINE unsafeResize #-}
+
+  unsafeExtract !sIx !newSz !arr = unsafeExtract sIx newSz (toManifest arr)
+  {-# INLINE unsafeExtract #-}
+
+
+instance ( NFData e
+         , Index ix
+         , Index (Lower ix)
+         , Elt M ix e ~ Array M (Lower ix) e
+         , Elt N ix e ~ Array M (Lower ix) e
+         ) =>
+         OuterSlice N ix e where
+  unsafeOuterSlice arr = unsafeOuterSlice (toManifest arr)
+  {-# INLINE unsafeOuterSlice #-}
+
+instance ( NFData e
+         , Index ix
+         , Index (Lower ix)
+         , Elt M ix e ~ Array M (Lower ix) e
+         , Elt N ix e ~ Array M (Lower ix) e
+         ) =>
+         InnerSlice N ix e where
+  unsafeInnerSlice arr = unsafeInnerSlice (toManifest arr)
+  {-# INLINE unsafeInnerSlice #-}
+
+
+instance (Index ix, NFData e) => Manifest N ix e where
+
+  unsafeLinearIndexM (NArray _ _ a) = A.indexArray a
+  {-# INLINE unsafeLinearIndexM #-}
+
+
+uninitialized :: a
+uninitialized = error "Data.Array.Massiv.Manifest.BoxedNF: uninitialized element"
+
+
+instance (Index ix, NFData e) => Mutable N ix e where
+  data MArray s N ix e = MNArray !ix {-# UNPACK #-} !(A.MutableArray s e)
+
+  msize (MNArray sz _) = sz
+  {-# INLINE msize #-}
+
+  unsafeThaw (NArray _ sz a) = MNArray sz <$> A.unsafeThawArray a
+  {-# INLINE unsafeThaw #-}
+
+  unsafeFreeze comp (MNArray sz ma) = NArray comp sz <$> A.unsafeFreezeArray ma
+  {-# INLINE unsafeFreeze #-}
+
+  unsafeNew sz = MNArray sz <$> A.newArray (totalElem sz) uninitialized
+  {-# INLINE unsafeNew #-}
+
+  unsafeNewZero = unsafeNew
+  {-# INLINE unsafeNewZero #-}
+
+  unsafeLinearRead (MNArray _ ma) i = A.readArray ma i
+  {-# INLINE unsafeLinearRead #-}
+
+  unsafeLinearWrite (MNArray _ ma) i e = e `deepseq` A.writeArray ma i e
+  {-# INLINE unsafeLinearWrite #-}
+
+
+deepseqArray :: (Index ix, NFData a) => ix -> A.Array a -> b -> b
+deepseqArray sz arr b =
+  iter 0 (totalElem sz) 1 (<) b $ \ !i acc -> A.indexArray arr i `deepseq` acc
+{-# INLINE deepseqArray #-}
+
+
+deepseqArrayP :: (Index ix, NFData a) => [Int] -> ix -> A.Array a -> b -> b
+deepseqArrayP wIds sz arr b =
+  unsafePerformIO $ do
+    divideWork_ wIds sz $ \ !scheduler !chunkLength !totalLength !slackStart -> do
+      loopM_ 0 (< slackStart) (+ chunkLength) $ \ !start ->
+        scheduleWork scheduler $
+        loopM_ start (< (start + chunkLength)) (+ 1) $ \ !k ->
+          A.indexArray arr k `deepseq` return ()
+      scheduleWork scheduler $
+        loopM_ slackStart (< totalLength) (+ 1) $ \ !k ->
+          A.indexArray arr k `deepseq` return ()
+    return b
+{-# INLINE deepseqArrayP #-}
+
+
+vectorFromArray :: Index ix => ix -> A.Array a -> VB.Vector a
+vectorFromArray sz arr = runST $ do
+  marr <- A.unsafeThawArray arr
+  VB.unsafeFreeze $ VB.MVector 0 (totalElem sz) marr
+{-# INLINE vectorFromArray #-}
+
+
+vectorToArray :: VB.Vector a -> A.Array a
+vectorToArray v =
+  runST $ do
+    VB.MVector start len marr <- VB.unsafeThaw v
+    marr' <-
+      if start == 0
+        then return marr
+        else A.cloneMutableArray marr start len
+    A.unsafeFreezeArray marr'
+{-# INLINE vectorToArray #-}
+
+
+-- | Cast a Boxed Vector into an Array, but only if it wasn't previously sliced.
+castVectorToArray :: VB.Vector a -> Maybe (A.Array a)
+castVectorToArray v =
+  runST $ do
+    VB.MVector start _ marr <- VB.unsafeThaw v
+    if start == 0
+      then Just <$> A.unsafeFreezeArray marr
+      else return Nothing
+{-# INLINE castVectorToArray #-}
+
+
+
+instance ( NFData e
+         , IsList (Array L ix e)
+         , Nested LN ix e
+         , Nested L ix e
+         , Ragged L ix e
+         ) =>
+         IsList (Array N ix e) where
+  type Item (Array N ix e) = Item (Array L ix e)
+  fromList = A.fromLists' Seq
+  {-# INLINE fromList #-}
+  toList = GHC.toList . toListArray
+  {-# INLINE toList #-}

--- a/massiv/src/Data/Massiv/Array/Manifest/BoxedStrict.hs
+++ b/massiv/src/Data/Massiv/Array/Manifest/BoxedStrict.hs
@@ -1,0 +1,182 @@
+{-# LANGUAGE BangPatterns          #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE DeriveGeneric         #-}
+-- |
+-- Module      : Data.Massiv.Array.Manifest.Boxed
+-- Copyright   : (c) Alexey Kuleshevich 2018
+-- License     : BSD3
+-- Maintainer  : Alexey Kuleshevich <lehins@yandex.ru>
+-- Stability   : experimental
+-- Portability : non-portable
+--
+module Data.Massiv.Array.Manifest.BoxedStrict
+  ( B (..)
+  , Array(..)
+  ) where
+
+import           Control.DeepSeq                     (NFData (..))
+import qualified Data.Foldable                       as F (Foldable (..))
+import           Data.Massiv.Array.Delayed.Internal  (eq, ord)
+import           Data.Massiv.Array.Manifest.BoxedNF  (deepseqArray,
+                                                      deepseqArrayP)
+import           Data.Massiv.Array.Unsafe            (unsafeGenerateArray,
+                                                      unsafeGenerateArrayP)
+import           Data.Massiv.Array.Manifest.Internal
+import           Data.Massiv.Array.Manifest.List     as A
+import           Data.Massiv.Array.Mutable
+import           Data.Massiv.Array.Ops.Fold.Internal
+import           Data.Massiv.Core.Common
+import           Data.Massiv.Core.List
+import qualified Data.Primitive.Array                as A
+import           GHC.Base                            (build)
+import           GHC.Exts                            as GHC (IsList (..))
+import           GHC.Generics (Generic)
+import           Prelude                             hiding (mapM)
+
+
+-- | Array representation for Boxed elements. This structure is element and
+-- spine strict, but elements are strict to Weak Head Normal Form (WHNF) only.
+data B = B deriving (Show, Generic)
+
+type instance EltRepr B ix = M
+
+data instance Array B ix e = BArray { bComp :: !Comp
+                                    , bSize :: !ix
+                                    , bData :: {-# UNPACK #-} !(A.Array e)
+                                    } deriving (Generic)
+
+instance (Index ix, NFData e) => NFData (Array B ix e) where
+  rnf (BArray comp sz arr) =
+    case comp of
+      Seq        -> deepseqArray sz arr ()
+      ParOn wIds -> deepseqArrayP wIds sz arr ()
+
+instance (Index ix, Eq e) => Eq (Array B ix e) where
+  (==) = eq (==)
+  {-# INLINE (==) #-}
+
+instance (Index ix, Ord e) => Ord (Array B ix e) where
+  compare = ord compare
+  {-# INLINE compare #-}
+
+instance Index ix => Construct B ix e where
+  getComp = bComp
+  {-# INLINE getComp #-}
+
+  setComp c arr = arr { bComp = c }
+  {-# INLINE setComp #-}
+
+  unsafeMakeArray Seq          !sz f = unsafeGenerateArray sz f
+  unsafeMakeArray (ParOn wIds) !sz f = unsafeGenerateArrayP wIds sz f
+  {-# INLINE unsafeMakeArray #-}
+
+instance Index ix => Source B ix e where
+  unsafeLinearIndex (BArray _ _ a) = A.indexArray a
+  {-# INLINE unsafeLinearIndex #-}
+
+
+instance Index ix => Size B ix e where
+  size = bSize
+  {-# INLINE size #-}
+
+  unsafeResize !sz !arr = arr { bSize = sz }
+  {-# INLINE unsafeResize #-}
+
+  unsafeExtract !sIx !newSz !arr = unsafeExtract sIx newSz (toManifest arr)
+  {-# INLINE unsafeExtract #-}
+
+
+instance ( NFData e
+         , Index ix
+         , Index (Lower ix)
+         , Elt M ix e ~ Array M (Lower ix) e
+         , Elt B ix e ~ Array M (Lower ix) e
+         ) =>
+         OuterSlice B ix e where
+  unsafeOuterSlice arr = unsafeOuterSlice (toManifest arr)
+  {-# INLINE unsafeOuterSlice #-}
+
+instance ( NFData e
+         , Index ix
+         , Index (Lower ix)
+         , Elt M ix e ~ Array M (Lower ix) e
+         , Elt B ix e ~ Array M (Lower ix) e
+         ) =>
+         InnerSlice B ix e where
+  unsafeInnerSlice arr = unsafeInnerSlice (toManifest arr)
+  {-# INLINE unsafeInnerSlice #-}
+
+
+instance Index ix => Manifest B ix e where
+
+  unsafeLinearIndexM (BArray _ _ a) = A.indexArray a
+  {-# INLINE unsafeLinearIndexM #-}
+
+
+uninitialized :: a
+uninitialized = error "Data.Array.Massiv.Manifest.BoxedStrict: uninitialized element"
+
+
+instance Index ix => Mutable B ix e where
+  data MArray s B ix e = MBArray !ix {-# UNPACK #-} !(A.MutableArray s e)
+
+  msize (MBArray sz _) = sz
+  {-# INLINE msize #-}
+
+  unsafeThaw (BArray _ sz a) = MBArray sz <$> A.unsafeThawArray a
+  {-# INLINE unsafeThaw #-}
+
+  unsafeFreeze comp (MBArray sz ma) = BArray comp sz <$> A.unsafeFreezeArray ma
+  {-# INLINE unsafeFreeze #-}
+
+  unsafeNew sz = MBArray sz <$> A.newArray (totalElem sz) uninitialized
+  {-# INLINE unsafeNew #-}
+
+  unsafeNewZero = unsafeNew
+  {-# INLINE unsafeNewZero #-}
+
+  unsafeLinearRead (MBArray _ ma) i = A.readArray ma i
+  {-# INLINE unsafeLinearRead #-}
+
+  unsafeLinearWrite (MBArray _ ma) i e = e `seq` A.writeArray ma i e
+  {-# INLINE unsafeLinearWrite #-}
+
+
+-- | Row-major sequential folding over a Boxed array.
+instance Index ix => Foldable (Array B ix) where
+  foldl = lazyFoldlS
+  {-# INLINE foldl #-}
+  foldl' = foldlS
+  {-# INLINE foldl' #-}
+  foldr = foldrFB
+  {-# INLINE foldr #-}
+  foldr' = foldrS
+  {-# INLINE foldr' #-}
+  null (BArray _ sz _) = totalElem sz == 0
+  {-# INLINE null #-}
+  sum = F.foldl' (+) 0
+  {-# INLINE sum #-}
+  product = F.foldl' (*) 1
+  {-# INLINE product #-}
+  length = totalElem . size
+  {-# INLINE length #-}
+  toList arr = build (\ c n -> foldrFB c n arr)
+  {-# INLINE toList #-}
+
+
+instance ( IsList (Array L ix e)
+         , Nested LN ix e
+         , Nested L ix e
+         , Ragged L ix e
+         ) =>
+         IsList (Array B ix e) where
+  type Item (Array B ix e) = Item (Array L ix e)
+  fromList = A.fromLists' Seq
+  {-# INLINE fromList #-}
+  toList = GHC.toList . toListArray
+  {-# INLINE toList #-}

--- a/massiv/src/Data/Massiv/Array/Manifest/Internal.hs
+++ b/massiv/src/Data/Massiv/Array/Manifest/Internal.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE DeriveGeneric         #-}
 -- |
 -- Module      : Data.Massiv.Array.Manifest.Internal
 -- Copyright   : (c) Alexey Kuleshevich 2018
@@ -52,15 +54,17 @@ import           Data.Maybe                          (fromMaybe)
 import           Data.Typeable
 import qualified Data.Vector                         as V
 import           GHC.Base                            (build)
+import           GHC.Generics
 import           System.IO.Unsafe                    (unsafePerformIO)
 
 
 -- | General Manifest representation
-data M
+data M deriving Generic
 
 data instance Array M ix e = MArray { mComp :: !Comp
                                     , mSize :: !ix
                                     , mUnsafeLinearIndex :: Int -> e }
+
 type instance EltRepr M ix = M
 
 instance Index ix => Construct M ix e where

--- a/massiv/src/Data/Massiv/Array/Manifest/Primitive.hs
+++ b/massiv/src/Data/Massiv/Array/Manifest/Primitive.hs
@@ -8,6 +8,8 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UnboxedTuples         #-}
 {-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE RecordWildCards       #-}
 -- |
 -- Module      : Data.Massiv.Array.Manifest.Primitive
 -- Copyright   : (c) Alexey Kuleshevich 2018
@@ -43,13 +45,14 @@ import           Data.Primitive.Types
 import qualified Data.Vector.Primitive               as VP
 import           GHC.Base                            (Int (..))
 import           GHC.Exts                            as GHC (IsList (..))
+import           GHC.Generics (Generic)
 import           GHC.Prim
 import           Prelude                             hiding (mapM)
 
 #include "massiv.h"
 
 -- | Representation for `Prim`itive elements
-data P = P deriving Show
+data P = P deriving (Show, Generic)
 
 type instance EltRepr P ix = M
 

--- a/massiv/src/Data/Massiv/Array/Manifest/Storable.hs
+++ b/massiv/src/Data/Massiv/Array/Manifest/Storable.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE CPP                   #-}
 {-# LANGUAGE FlexibleContexts      #-}
@@ -6,6 +7,7 @@
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE DeriveGeneric         #-}
 -- |
 -- Module      : Data.Massiv.Array.Manifest.Storable
 -- Copyright   : (c) Alexey Kuleshevich 2018
@@ -37,19 +39,20 @@ import qualified Data.Vector.Storable                as VS
 import qualified Data.Vector.Storable.Mutable        as MVS
 import           Foreign.Ptr
 import           GHC.Exts                            as GHC (IsList (..))
+import           GHC.Generics (Generic)
 import           Prelude                             hiding (mapM)
 
 #include "massiv.h"
 
 -- | Representation for `Storable` elements
-data S = S deriving Show
+data S = S deriving (Show, Generic)
 
 type instance EltRepr S ix = M
 
 data instance Array S ix e = SArray { sComp :: !Comp
                                     , sSize :: !ix
                                     , sData :: !(VS.Vector e)
-                                    }
+                                    } deriving (Generic)
 
 
 instance (Index ix, NFData e) => NFData (Array S ix e) where

--- a/massiv/src/Data/Massiv/Array/Manifest/Unboxed.hs
+++ b/massiv/src/Data/Massiv/Array/Manifest/Unboxed.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE CPP                   #-}
 {-# LANGUAGE FlexibleContexts      #-}
@@ -5,6 +6,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE UndecidableInstances  #-}
 -- |
 -- Module      : Data.Massiv.Array.Manifest.Unboxed
@@ -34,20 +36,20 @@ import           Data.Massiv.Core.List
 import qualified Data.Vector.Unboxed                 as VU
 import qualified Data.Vector.Unboxed.Mutable         as MVU
 import           GHC.Exts                            as GHC (IsList (..))
+import           GHC.Generics (Generic)
 import           Prelude                             hiding (mapM)
 
 #include "massiv.h"
 
 -- | Representation for `Unbox`ed elements
-data U = U deriving Show
+data U = U deriving (Show, Generic)
 
 type instance EltRepr U ix = M
 
 data instance Array U ix e = UArray { uComp :: !Comp
                                     , uSize :: !ix
                                     , uData :: !(VU.Vector e)
-                                    }
-
+                                    } deriving (Generic)
 
 instance (Index ix, NFData e) => NFData (Array U ix e) where
   rnf (UArray c sz v) = c `deepseq` sz `deepseq` v `deepseq` ()

--- a/massiv/src/Data/Massiv/Array/Stencil/Internal.hs
+++ b/massiv/src/Data/Massiv/Array/Stencil/Internal.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE DeriveGeneric         #-}
 -- |
 -- Module      : Data.Massiv.Array.Stencil.Internal
 -- Copyright   : (c) Alexey Kuleshevich 2018
@@ -23,6 +24,7 @@ import           Data.Massiv.Core.Common
 #if !MIN_VERSION_base(4,11,0)
 import           Data.Semigroup
 #endif
+import           GHC.Generics (Generic)
 
 -- | Stencil is abstract description of how to handle elements in the neighborhood of every array
 -- cell in order to compute a value for the cells in the new array. Use `Data.Array.makeStencil` and
@@ -39,7 +41,7 @@ instance Index ix => NFData (Stencil ix e a) where
 -- | This is a simple wrapper for value of an array cell. It is used in order to improve safety of
 -- `Stencil` mapping. Using various class instances, such as `Num` and `Functor` for example, make
 -- it possible to manipulate the value, without having direct access to it.
-newtype Value e = Value { unValue :: e } deriving (Show, Bounded)
+newtype Value e = Value { unValue :: e } deriving (Show, Bounded, Generic)
 
 instance Functor Value where
   fmap f (Value e) = Value (f e)

--- a/massiv/src/Data/Massiv/Core/Computation.hs
+++ b/massiv/src/Data/Massiv/Core/Computation.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE PatternSynonyms     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DeriveGeneric       #-}
 -- |
 -- Module      : Data.Massiv.Core.Computation
 -- Copyright   : (c) Alexey Kuleshevich 2018
@@ -18,6 +19,7 @@ import           Control.DeepSeq (NFData (..), deepseq)
 #if !MIN_VERSION_base(4,11,0)
 import           Data.Semigroup
 #endif
+import           GHC.Generics
 
 
 -- | Computation type to use.
@@ -33,7 +35,7 @@ data Comp
   -- @+RTS -Nx@ or at compile time by GHC flag @-with-rtsopts=-Nx@,
   -- where @x@ is the number of capabilities. Ommiting @x@ in above flags
   -- defaults to number available cores.
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
 
 -- | Parallel computation using all available cores.
 pattern Par :: Comp

--- a/massiv/src/Data/Massiv/Core/Index.hs
+++ b/massiv/src/Data/Massiv/Core/Index.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE DeriveGeneric              #-}
 -- |
 -- Module      : Data.Massiv.Core.Index
 -- Copyright   : (c) Alexey Kuleshevich 2018
@@ -33,6 +34,7 @@ import           Control.DeepSeq
 import           Data.Massiv.Core.Index.Class
 import           Data.Massiv.Core.Index.Ix
 import           Data.Massiv.Core.Iterator
+import           GHC.Generics
 
 
 -- | Approach to be used near the borders during various transformations.
@@ -75,7 +77,7 @@ data Border e =
               -- 'Continue' : 1 4 3 2 | 1 2 3 4 | 3 2 1 4
               -- @
               --
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 instance NFData e => NFData (Border e) where
   rnf b = case b of

--- a/massiv/src/Data/Massiv/Core/Index/Class.hs
+++ b/massiv/src/Data/Massiv/Core/Index/Class.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE DeriveGeneric              #-}
 -- |
 -- Module      : Data.Massiv.Core.Index.Class
 -- Copyright   : (c) Alexey Kuleshevich 2018
@@ -20,13 +22,14 @@ import           Control.DeepSeq           (NFData (..))
 import           Data.Functor.Identity     (runIdentity)
 import           Data.Massiv.Core.Iterator
 import           GHC.TypeLits
+import           GHC.Generics (Generic)
 
 -- | A way to select Array dimension.
 newtype Dim = Dim Int deriving (Show, Eq, Ord, Num, Real, Integral, Enum)
 
 -- | Zero-dimension, i.e. a scalar. Can't really be used directly as there are no instances of
 -- `Index` for it, and is included for completeness.
-data Ix0 = Ix0 deriving (Eq, Ord, Show)
+data Ix0 = Ix0 deriving (Eq, Ord, Show, Generic)
 
 -- | 1-dimensional index. Synonym for `Int` and `Data.Massiv.Core.Index.Ix1`.
 type Ix1T = Int

--- a/massiv/src/Data/Massiv/Core/Index/Ix.hs
+++ b/massiv/src/Data/Massiv/Core/Index/Ix.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE TypeFamilies           #-}
 {-# LANGUAGE TypeOperators          #-}
 {-# LANGUAGE UndecidableInstances   #-}
+{-# LANGUAGE DeriveGeneric          #-}
 
 #if __GLASGOW_HASKELL__ >= 800
 {-# LANGUAGE TypeFamilyDependencies #-}
@@ -34,6 +35,7 @@ import qualified Data.Vector.Generic          as V
 import qualified Data.Vector.Generic.Mutable  as VM
 import qualified Data.Vector.Unboxed          as VU
 import           GHC.TypeLits
+import           GHC.Generics
 
 
 infixr 5 :>, :.
@@ -48,7 +50,7 @@ pattern Ix1 :: Int -> Ix1
 pattern Ix1 i = i
 
 -- | 2-dimensional index. This also a base index for higher dimensions.
-data Ix2 = (:.) {-# UNPACK #-} !Int {-# UNPACK #-} !Int
+data Ix2 = (:.) {-# UNPACK #-} !Int {-# UNPACK #-} !Int deriving (Generic)
 
 -- | 2-dimensional index constructor. Useful when @TypeOperators@ extension isn't enabled, or simply
 -- infix notation is inconvenient. @(Ix2 i j) == (i :. j)@.
@@ -79,7 +81,7 @@ pattern Ix5 i j k l m = i :> j :> k :> l :. m
 #if __GLASGOW_HASKELL__ >= 800
 
 -- | n-dimensional index. Needs a base case, which is the `Ix2`.
-data IxN (n :: Nat) = (:>) {-# UNPACK #-} !Int !(Ix (n - 1))
+data IxN (n :: Nat) = (:>) {-# UNPACK #-} !Int !(Ix (n - 1)) deriving Generic
 
 -- | Defines n-dimensional index by relating a general `IxN` with few base cases.
 type family Ix (n :: Nat) = r | r -> n where

--- a/massiv/src/Data/Massiv/Core/List.hs
+++ b/massiv/src/Data/Massiv/Core/List.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE DeriveGeneric         #-}
 -- |
 -- Module      : Data.Massiv.Core.List
 -- Copyright   : (c) Alexey Kuleshevich 2018
@@ -37,9 +38,10 @@ import           Data.Massiv.Core.Scheduler
 import           Data.Proxy
 import           Data.Typeable
 import           GHC.Exts
+import           GHC.Generics (Generic)
 import           System.IO.Unsafe           (unsafePerformIO)
 
-data LN
+data LN deriving Generic
 
 type instance EltRepr LN ix = LN
 
@@ -49,8 +51,7 @@ type family ListItem ix e :: * where
 
 type instance NestedStruct LN ix e = [ListItem ix e]
 
-newtype instance Array LN ix e = List { unList :: [Elt LN ix e] }
-
+newtype instance Array LN ix e = List { unList :: [Elt LN ix e] } deriving Generic
 
 instance {-# OVERLAPPING #-} Nested LN Ix1 e where
   fromNested = coerce
@@ -77,19 +78,17 @@ instance Nested LN ix e => IsList (Array LN ix e) where
   {-# INLINE toList #-}
 
 
-data L = L
+data L = L deriving Generic
 type instance EltRepr L ix = L
 
 type instance NestedStruct L ix e = Array LN ix e
 
 data instance Array L ix e = LArray { lComp :: Comp
-                                    , lData :: !(Array LN ix e) }
-
-
+                                    , lData :: !(Array LN ix e) } deriving Generic
 
 data ShapeError = RowTooShortError
                 | RowTooLongError
-                deriving Show
+                deriving (Show, Generic)
 
 instance Exception ShapeError
 

--- a/massiv/stack-ghc-8.4.yaml
+++ b/massiv/stack-ghc-8.4.yaml
@@ -1,10 +1,8 @@
-resolver: lts-9.20
+resolver: nightly-2018-03-14
 packages:
 - '.'
-- '../massiv/'
 extra-deps:
-- repa-3.4.1.3
-- repa-algorithms-3.4.1.2
+- safe-exceptions-0.1.7.0
 - validity-0.6.0.0
 flags: {}
 extra-package-dbs: []

--- a/massiv/stack.lts-3.yaml
+++ b/massiv/stack.lts-3.yaml
@@ -3,5 +3,6 @@ packages:
 - '.'
 extra-deps:
 - safe-exceptions-0.1.6.0
+- validity-0.6.0.0
 flags: {}
 extra-package-dbs: []

--- a/massiv/stack.yaml
+++ b/massiv/stack.yaml
@@ -1,6 +1,7 @@
 resolver: lts-9.21
 packages:
 - '.'
-extra-deps: []
+extra-deps:
+- validity-0.6.0.0
 flags: {}
 extra-package-dbs: []

--- a/validity-massiv/.gitignore
+++ b/validity-massiv/.gitignore
@@ -1,0 +1,3 @@
+.stack-work/
+validity-massiv.cabal
+*~

--- a/validity-massiv/ChangeLog.md
+++ b/validity-massiv/ChangeLog.md
@@ -1,0 +1,3 @@
+# Changelog for validity-massiv
+
+## Unreleased changes

--- a/validity-massiv/LICENSE
+++ b/validity-massiv/LICENSE
@@ -1,0 +1,30 @@
+Copyright Nick Van den Broeck (c) 2018
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Nick Van den Broeck nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/validity-massiv/README.md
+++ b/validity-massiv/README.md
@@ -1,0 +1,1 @@
+# validity-massiv

--- a/validity-massiv/Setup.hs
+++ b/validity-massiv/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/validity-massiv/package.yaml
+++ b/validity-massiv/package.yaml
@@ -17,6 +17,7 @@ dependencies:
 - massiv
 - primitive
 - validity >= 0.7
+- vector
 
 library:
   source-dirs: src

--- a/validity-massiv/package.yaml
+++ b/validity-massiv/package.yaml
@@ -1,0 +1,40 @@
+name:                validity-massiv
+version:             0.1.0.0
+github:              "lehins/validity-massiv"
+license:             BSD3
+author:              "Nick Van den Broeck"
+maintainer:          "alexey@kuleshevi.ch"
+copyright:           "2018 Nick Van den Broeck"
+
+extra-source-files:
+- README.md
+- ChangeLog.md
+
+description:         Please see the README on GitHub at <https://github.com/lehins/validity-massiv#readme>
+
+dependencies:
+- base >= 4.7 && < 5
+- massiv
+- primitive
+- validity >= 0.7
+
+library:
+  source-dirs: src
+  ghc-options: -Wall
+  default-extensions:
+  - NoImplicitPrelude
+  exposed-modules:
+  - Data.Validity.Massiv
+  other-modules:
+  - Import
+
+tests:
+  validity-massiv-test:
+    main:                Spec.hs
+    source-dirs:         test
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    dependencies:
+    - validity-massiv

--- a/validity-massiv/src/Data/Validity/Massiv.hs
+++ b/validity-massiv/src/Data/Validity/Massiv.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Data.Validity.Massiv where
@@ -9,6 +12,12 @@ import Import
 
 import Data.Massiv.Array
 import Data.Massiv.Core
+
+import qualified Data.Primitive.Array as A
+import qualified Data.Vector.Storable as SV
+import qualified Data.Vector.Unboxed as UV
+
+import qualified GHC.Exts as GHC (IsList(..))
 
 instance Validity Comp
 
@@ -35,42 +44,45 @@ instance Validity (Ix (n - 1)) => Validity (IxN n)
 
 instance Validity DI
 
-instance (Index ix, Validity ix, Validity e) => Validity (Array DI ix e)
-
+--instance (Index ix, Validity ix, Validity e) => Validity (Array DI ix e)
 instance Validity D
 
-instance (Index ix, Validity ix, Validity e) => Validity (Array D ix e) where
-    validate DArray {..} =
-        mconcat
-            [ delve "comp" dComp
-            , delve "size" dSize
-            , decorate "array" $ validateFunc (pureIndex 0) dSize dUnsafeIndex
-            ]
-
+--instance (Index ix, Validity ix, Validity e) => Validity (Array D ix e) where
+--    validate arr =
+--        mconcat
+--            [ delve "comp" $ getComp arr
+--            , delve "size" $ getSize arr
+--            , decorate "array" $ validateFunc (pureIndex 0) dSize dUnsafeIndex
+--            ]
 instance Validity DW
 
-instance (Num ix, Index ix, Validity ix, Validity (Array D ix e), Validity e) =>
-         Validity (Array DW ix e) where
-    validate DWArray {..} =
-        mconcat
-            [ delve "Array D" wdArray
-            , delve "stencil size" wdStencilSize
-            , delve "window start index" wdWindowStartIndex
-            , delve "window size" wdWindowSize
-            , declare "window start index must be positive" $
-              wdWindowStartInde x >= pureIndex 0
-            , declare "window fits in array" $
-              wdWindowStartIndex + wdWindowSiz e <= size wdArray
-            , validateFunc
-                  wdWindowStartIndex
-                  (wdWindowStartIndex + wdWindowSiz e)
-                  wdWindowUnsafeIndex
-            ]
-
+--instance (Num ix, Index ix, Validity ix, Validity (Array D ix e), Validity e) =>
+--         Validity (Array DW ix e) where
+--    validate DWArray {..} =
+--        mconcat
+--            [ delve "Array D" wdArray
+--            , delve "stencil size" wdStencilSize
+--            , delve "window start index" wdWindowStartIndex
+--            , delve "window size" wdWindowSize
+--            , declare "window start index must be positive" $
+--              wdWindowStartInde x >= pureIndex 0
+--            , declare "window fits in array" $
+--              wdWindowStartIndex + wdWindowSiz e <= size wdArray
+--            , validateFunc
+--                  wdWindowStartIndex
+--                  (wdWindowStartIndex + wdWindowSiz e)
+--                  wdWindowUnsafeIndex
+--            ]
 instance Validity P
 
+--instance (Validity ix, Index ix) => Validity (Array P ix e) where
+--    validate arr =
+--        delve "comp" (getComp arr) `mappend` delve "size" (getSize arr)
+--
 instance (Validity ix, Index ix) => Validity (Array P ix e) where
-    validate PArray {..} = delve "comp" pComp `mappend` delve "size" pSize
+    validate arr =
+        delve "comp" (getComp arr) <> delve "size" (getSize arr) <>
+        delve "data" (toByteArray arr)
 
 instance Validity N
 #if MIN_VERSION_primitive(0,6,2)
@@ -89,10 +101,10 @@ instance (Validity ix, Index ix, Validity e) => Validity (Array B ix e)
 instance Validity M
 
 instance (Validity ix, Index ix, Validity e) => Validity (Array M ix e) where
-    validate MArray {..} =
+    validate arr =
         mconcat
-            [ delve "comp" mComp
-            , delve "size" mSize
+            [ delve "comp" $ getComp arr
+            , delve "size" $ getSize arr
             , decorate "Array M elements" $
               checkUnsafeLinearIndex (totalElem m Size) mUnsafeLinearIndex
             ]
@@ -102,33 +114,32 @@ checkUnsafeLinearIndex n func = foldMap (validate . func) $ [0 .. n - 1]
 
 instance Validity S
 
-instance (MVS.Storable e, Validity e) => Validity (VS.Vector e) where
+instance (SV.Storable e, Validity e) => Validity (SV.Vector e) where
     validate = declare "elements" . foldMap validate . GHC.toList
 
-instance (MVS.Storable e, Validity ix, Index ix, Validity e) =>
-         Validity (A rray S ix e)
+instance (SV.Storable e, Validity ix, Index ix, Validity e) =>
+         Validity (Array S ix e)
 
 instance Validity U
 
-instance (MVU.Unbox e, Validity e) => Validity (VU.Vector e) where
+instance (UV.Unbox e, Validity e) => Validity (UV.Vector e) where
     validate =
         declare "elements" .
-        VU.foldl' (\val x -> val `mappend` validate x) mempty
+        UV.foldl' (\val x -> val `mappend` validate x) mempty
 
-instance (MVU.Unbox e, Validity ix, Index ix, Validity e) =>
-         Validity (Arra y U ix e)
+instance (UV.Unbox e, Validity ix, Index ix, Validity e) =>
+         Validity (Array U ix e)
 
-validateFunc :: (Index ix, Validity e) => ix -> ix -> (ix -> e) -> Validati on
+validateFunc :: (Index ix, Validity e) => ix -> ix -> (ix -> e) -> Validation
 validateFunc initial sz arr =
     iter initial sz 1 (<) valid $ \ix validation ->
         validate (arr ix) `mappend` validation
 
-instance (Validity ix, Index ix) => Validity (Stencil ix e a) where
-    validate Stencil {..} =
-        mconcat
-            [ delve "size" stencilSize
-            , delve "center" stencilCenter
-            , declare "center < size" $ stencilCenter < stencilSize
-            ]
-
+--instance (Validity ix, Index ix) => Validity (Stencil ix e a) where
+--    validate Stencil {..} =
+--        mconcat
+--            [ delve "size" stencilSize
+--            , delve "center" stencilCenter
+--            , declare "center < size" $ stencilCenter < stencilSize
+--            ]
 instance Validity e => Validity (Value e)

--- a/validity-massiv/src/Data/Validity/Massiv.hs
+++ b/validity-massiv/src/Data/Validity/Massiv.hs
@@ -1,0 +1,134 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Data.Validity.Massiv where
+
+import Import
+
+import Data.Massiv.Array
+import Data.Massiv.Core
+
+instance Validity Comp
+
+instance Validity Dim where
+    validate (Dim n) = declare "A Dim is positive" $ n >= 0
+
+instance Validity Ix0
+
+--instance Validity (State s) where
+--    validate = trivialValidation
+instance Validity LN
+
+instance Validity L
+
+instance Validity (Elt LN ix e) => Validity (Array L ix e)
+
+instance Validity (Elt LN ix e) => Validity (Array LN ix e)
+
+instance (Generic e, Validity e) => Validity (Border e)
+
+instance Validity Ix2
+
+instance Validity (Ix (n - 1)) => Validity (IxN n)
+
+instance Validity DI
+
+instance (Index ix, Validity ix, Validity e) => Validity (Array DI ix e)
+
+instance Validity D
+
+instance (Index ix, Validity ix, Validity e) => Validity (Array D ix e) where
+    validate DArray {..} =
+        mconcat
+            [ delve "comp" dComp
+            , delve "size" dSize
+            , decorate "array" $ validateFunc (pureIndex 0) dSize dUnsafeIndex
+            ]
+
+instance Validity DW
+
+instance (Num ix, Index ix, Validity ix, Validity (Array D ix e), Validity e) =>
+         Validity (Array DW ix e) where
+    validate DWArray {..} =
+        mconcat
+            [ delve "Array D" wdArray
+            , delve "stencil size" wdStencilSize
+            , delve "window start index" wdWindowStartIndex
+            , delve "window size" wdWindowSize
+            , declare "window start index must be positive" $
+              wdWindowStartInde x >= pureIndex 0
+            , declare "window fits in array" $
+              wdWindowStartIndex + wdWindowSiz e <= size wdArray
+            , validateFunc
+                  wdWindowStartIndex
+                  (wdWindowStartIndex + wdWindowSiz e)
+                  wdWindowUnsafeIndex
+            ]
+
+instance Validity P
+
+instance (Validity ix, Index ix) => Validity (Array P ix e) where
+    validate PArray {..} = delve "comp" pComp `mappend` delve "size" pSize
+
+instance Validity N
+#if MIN_VERSION_primitive(0,6,2)
+instance Validity a => Validity (A.Array a) where
+    validate = foldMap validate
+#else
+instance Validity a => Validity (A.Array a) where
+    validate = trivialValidation
+#endif
+instance (Validity ix, Index ix, Validity e) => Validity (Array N ix e)
+
+instance Validity B
+
+instance (Validity ix, Index ix, Validity e) => Validity (Array B ix e)
+
+instance Validity M
+
+instance (Validity ix, Index ix, Validity e) => Validity (Array M ix e) where
+    validate MArray {..} =
+        mconcat
+            [ delve "comp" mComp
+            , delve "size" mSize
+            , decorate "Array M elements" $
+              checkUnsafeLinearIndex (totalElem m Size) mUnsafeLinearIndex
+            ]
+
+checkUnsafeLinearIndex :: Validity e => Int -> (Int -> e) -> Validation
+checkUnsafeLinearIndex n func = foldMap (validate . func) $ [0 .. n - 1]
+
+instance Validity S
+
+instance (MVS.Storable e, Validity e) => Validity (VS.Vector e) where
+    validate = declare "elements" . foldMap validate . GHC.toList
+
+instance (MVS.Storable e, Validity ix, Index ix, Validity e) =>
+         Validity (A rray S ix e)
+
+instance Validity U
+
+instance (MVU.Unbox e, Validity e) => Validity (VU.Vector e) where
+    validate =
+        declare "elements" .
+        VU.foldl' (\val x -> val `mappend` validate x) mempty
+
+instance (MVU.Unbox e, Validity ix, Index ix, Validity e) =>
+         Validity (Arra y U ix e)
+
+validateFunc :: (Index ix, Validity e) => ix -> ix -> (ix -> e) -> Validati on
+validateFunc initial sz arr =
+    iter initial sz 1 (<) valid $ \ix validation ->
+        validate (arr ix) `mappend` validation
+
+instance (Validity ix, Index ix) => Validity (Stencil ix e a) where
+    validate Stencil {..} =
+        mconcat
+            [ delve "size" stencilSize
+            , delve "center" stencilCenter
+            , declare "center < size" $ stencilCenter < stencilSize
+            ]
+
+instance Validity e => Validity (Value e)

--- a/validity-massiv/src/Import.hs
+++ b/validity-massiv/src/Import.hs
@@ -1,0 +1,16 @@
+module Import
+    ( module X
+    ) where
+
+import Prelude as X
+
+import GHC.Generics as X hiding (D, S)
+import GHC.Natural as X
+import GHC.TypeLits as X
+
+import Data.List as X hiding (transpose)
+import Data.Maybe as X
+import Data.Monoid as X hiding (Last)
+import Data.Validity as X
+
+import Control.Applicative as X

--- a/validity-massiv/stack.yaml
+++ b/validity-massiv/stack.yaml
@@ -1,0 +1,8 @@
+resolver: lts-11.6
+packages:
+- .
+- ../massiv
+nix:
+  packages: [zlib]
+extra-deps:
+- validity-0.7.0.0

--- a/validity-massiv/stack.yaml
+++ b/validity-massiv/stack.yaml
@@ -1,8 +1,8 @@
 resolver: lts-11.6
 packages:
 - .
-- ../massiv
+- '../massiv'
 nix:
-  packages: [zlib]
+  packages: [ zlib ]
 extra-deps:
 - validity-0.7.0.0

--- a/validity-massiv/test/Spec.hs
+++ b/validity-massiv/test/Spec.hs
@@ -1,0 +1,2 @@
+main :: IO ()
+main = putStrLn "Test suite not yet implemented"


### PR DESCRIPTION
This package stores GenUnchecked and GenValid instances,
so that they can be imported separately by anyone writing tests
for their code which depends on Massiv.