### PR TITLE
Add matrix-vector product

### DIFF
--- a/massiv/CHANGELOG.md
+++ b/massiv/CHANGELOG.md
@@ -1,12 +1,9 @@
-# 0.5.3
-
-* Add matrix-vector product (`(#>)`)
-
 # 0.5.2
 
 * Addition of `lowerTriangular` and `upperTriangular`
 * Relax `identityMatrix` type to return an array of any `Num` type, not just `Int`.
 * Addition of `unsafeMakeLoadArrayAdjusted`
+* Add matrix-vector product (`(#>)`)
 
 # 0.5.1
 

--- a/massiv/CHANGELOG.md
+++ b/massiv/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.3
+
+* Add matrix-vector product (`(#>)`)
+
 # 0.5.2
 
 * Addition of `lowerTriangular` and `upperTriangular`

--- a/massiv/massiv.cabal
+++ b/massiv/massiv.cabal
@@ -1,5 +1,5 @@
 name:                massiv
-version:             0.5.3.0
+version:             0.5.2.0
 synopsis:            Massiv (Массив) is an Array Library.
 description:         Multi-dimensional Arrays with fusion, stencils and parallel computation.
 homepage:            https://github.com/lehins/massiv

--- a/massiv/massiv.cabal
+++ b/massiv/massiv.cabal
@@ -1,5 +1,5 @@
 name:                massiv
-version:             0.5.2.0
+version:             0.5.3.0
 synopsis:            Massiv (Массив) is an Array Library.
 description:         Multi-dimensional Arrays with fusion, stencils and parallel computation.
 homepage:            https://github.com/lehins/massiv

--- a/massiv/src/Data/Massiv/Array/Numeric.hs
+++ b/massiv/src/Data/Massiv/Array/Numeric.hs
@@ -218,6 +218,8 @@ liftNumericArray2M f a1 a2
 -- | Matrix-vector product
 --
 -- Inner dimensions must agree, otherwise `SizeElementsMismatchException`
+--
+-- @since 0.5.3
 (#>) :: (MonadThrow m, Source (R r') Ix1 e, Source r Ix1 e, Construct r' Ix1 e, Load r Ix1 e, Load r' Ix2 e, OuterSlice r' Ix2 e, Num e) => Array r' Ix2 e -> Array r Ix1 e -> m (Array r' Ix1 e)
 mm #> v
   | mCols /= n = throwM $ SizeElementsMismatchException (size mm) (size v)

--- a/massiv/src/Data/Massiv/Array/Numeric.hs
+++ b/massiv/src/Data/Massiv/Array/Numeric.hs
@@ -219,8 +219,11 @@ liftNumericArray2M f a1 a2
 --
 -- Inner dimensions must agree, otherwise `SizeMismatchException`
 --
--- @since 0.5.3
-(#>) :: (MonadThrow m, Source (R r') Ix1 e, Source r Ix1 e, Construct r' Ix1 e, Load r Ix1 e, Load r' Ix2 e, OuterSlice r' Ix2 e, Num e) => Array r' Ix2 e -> Array r Ix1 e -> m (Array r' Ix1 e)
+-- @since 0.5.2
+(#>) :: (MonadThrow m, Source (R r') Ix1 e, Source r Ix1 e, Construct r' Ix1 e, Load r Ix1 e, Load r' Ix2 e, OuterSlice r' Ix2 e, Num e)
+  => Array r' Ix2 e -- ^ Matrix
+  -> Array r Ix1 e -- ^ Vector
+  -> m (Array D Ix1 e)
 mm #> v
   | mCols /= n = throwM $ SizeMismatchException (size mm) (Sz2 n 1)
   | otherwise = pure $ makeArray (getComp mm <> getComp v) (Sz1 mRows) $ \i ->
@@ -235,6 +238,7 @@ mm #> v
 multiplyTransposedFused ::
      ( Mutable r Ix2 e
      , OuterSlice r Ix2 e
+     
      , Source (R r) Ix1 e
      , Num e
      , MonadThrow m

--- a/massiv/src/Data/Massiv/Array/Numeric.hs
+++ b/massiv/src/Data/Massiv/Array/Numeric.hs
@@ -217,12 +217,12 @@ liftNumericArray2M f a1 a2
 
 -- | Matrix-vector product
 --
--- Inner dimensions must agree, otherwise `SizeElementsMismatchException`
+-- Inner dimensions must agree, otherwise `SizeMismatchException`
 --
 -- @since 0.5.3
 (#>) :: (MonadThrow m, Source (R r') Ix1 e, Source r Ix1 e, Construct r' Ix1 e, Load r Ix1 e, Load r' Ix2 e, OuterSlice r' Ix2 e, Num e) => Array r' Ix2 e -> Array r Ix1 e -> m (Array r' Ix1 e)
 mm #> v
-  | mCols /= n = throwM $ SizeElementsMismatchException (size mm) (size v)
+  | mCols /= n = throwM $ SizeMismatchException (size mm) (Sz2 n 1)
   | otherwise = pure $ makeArray (getComp mm <> getComp v) (Sz1 mRows) $ \i ->
       A.foldlS (+) 0 (A.zipWith (*) (unsafeOuterSlice mm i) v)
   where

--- a/massiv/src/Data/Massiv/Array/Numeric.hs
+++ b/massiv/src/Data/Massiv/Array/Numeric.hs
@@ -220,10 +220,10 @@ liftNumericArray2M f a1 a2
 -- Inner dimensions must agree, otherwise `SizeMismatchException`
 --
 -- @since 0.5.2
-(#>) :: (MonadThrow m, Source (R r') Ix1 e, Source r Ix1 e, Construct r' Ix1 e, Load r Ix1 e, Load r' Ix2 e, OuterSlice r' Ix2 e, Num e)
-  => Array r' Ix2 e -- ^ Matrix
-  -> Array r Ix1 e -- ^ Vector
-  -> m (Array D Ix1 e)
+(#>) :: (MonadThrow m, Num e, Source (R r) Ix1 e, Manifest r' Ix1 e, OuterSlice r Ix2 e) =>
+        Array r Ix2 e -- ^ Matrix
+     -> Array r' Ix1 e -- ^ Vector
+     -> m (Array D Ix1 e)
 mm #> v
   | mCols /= n = throwM $ SizeMismatchException (size mm) (Sz2 n 1)
   | otherwise = pure $ makeArray (getComp mm <> getComp v) (Sz1 mRows) $ \i ->

--- a/massiv/src/Data/Massiv/Array/Numeric.hs
+++ b/massiv/src/Data/Massiv/Array/Numeric.hs
@@ -23,6 +23,7 @@ module Data.Massiv.Array.Numeric
   , (.*)
   , (*.)
   , (.^)
+  , (#>)
   , (|*|)
   , multiplyTransposed
   , identityMatrix
@@ -258,8 +259,7 @@ multArrs arr1 arr2 = multiplyTransposed arr1 arr2'
     arr2' = compute $ transpose arr2
 {-# INLINE multArrs #-}
 
--- | It is quite often that second matrix gets transposed before multiplication (eg. A * A'), but
--- due to layout of data in memory it is more efficient to transpose the second array again.
+-- | Computes the matrix-matrix transposed product (i.e. A * A')
 multiplyTransposed ::
      ( Manifest r Ix2 e
      , OuterSlice r Ix2 e

--- a/massiv/src/Data/Massiv/Array/Numeric.hs
+++ b/massiv/src/Data/Massiv/Array/Numeric.hs
@@ -224,7 +224,7 @@ liftNumericArray2M f a1 a2
 mm #> v
   | mCols /= n = throwM $ SizeElementsMismatchException (size mm) (size v)
   | otherwise = pure $ makeArray (getComp mm <> getComp v) (Sz1 mRows) $ \i ->
-      foldlS (+) 0 (zipWith (*) (unsafeOuterSlice mm i) v)
+      A.foldlS (+) 0 (A.zipWith (*) (unsafeOuterSlice mm i) v)
   where
     Sz2 mRows mCols = size mm
     Sz1 n = size v

--- a/massiv/src/Data/Massiv/Array/Numeric.hs
+++ b/massiv/src/Data/Massiv/Array/Numeric.hs
@@ -231,7 +231,7 @@ mm #> v
   where
     Sz2 mRows mCols = size mm
     Sz1 n = size v
-{-# INLINE [1] (#>) #-}
+{-# INLINE (#>) #-}
 
 
 

--- a/massiv/src/Data/Massiv/Array/Numeric.hs
+++ b/massiv/src/Data/Massiv/Array/Numeric.hs
@@ -238,7 +238,6 @@ mm #> v
 multiplyTransposedFused ::
      ( Mutable r Ix2 e
      , OuterSlice r Ix2 e
-     
      , Source (R r) Ix1 e
      , Num e
      , MonadThrow m


### PR DESCRIPTION
Add matrix-vector product `(#>)` in Numeric 


* [x] Bump up the version in cabal file
* [x] Any changes that could be relevant to users have been recorded in the `CHANGELOG.md`
* [x] The documentation has been updated, if necessary.
* [ ] Property tests or at least some unit test cases been added for all new functionality.
* [ ] Link to any issues that might be related to this Pull Request.
