### PR TITLE
Massiv is marked broken under NixOS as doctests can't find massiv.h

### DIFF
--- a/massiv/CHANGELOG.md
+++ b/massiv/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Relax argument of `snoc` and `cons` constraint to `Load` vectors
 * Improve `unsnocM` and `unconsM` by switching to `unsafeLinearSlice`, instead of delaying
   the array.
+* Fix massiv doctests not being able to find massiv.h under NixOS
 
 # 0.5.2
 

--- a/massiv/tests/doctests.hs
+++ b/massiv/tests/doctests.hs
@@ -3,4 +3,4 @@ module Main where
 import Test.DocTest (doctest)
 
 main :: IO ()
-main = doctest ["src"]
+main = doctest ["-Iinclude","src"]


### PR DESCRIPTION
It isn't possible to install massiv under NixOS as the test phase of the build is failing due to not being able to find _massiv.h_

```
running tests
Running 1 test suites...
Test suite doctests: RUNNING...

src/Data/Massiv/Array/Delayed/Pull.hs:37:2: error:
     fatal error: massiv.h: No such file or directory
       37 | 
          |  ^         
   |
37 | 
   |  ^
compilation terminated.

...
```

After some mucking around, I determined it was caused by doctests not having the required `-Iinclude` option. I've added this, tested it inside of `nix-shell`, and it was able to complete the test phase okay.

I didn't bump the current version number in the cabal file as the guide below suggests as I noticed it was a few behind the current one in the CHANGELOG. Instead I just added a comment to the end of the current list in the CHANGELOG as I presume you are accumulating them.

Please include this checklist whenever changes are introduced to either `massiv` or `massiv-io` packages:

* [ ] Bump up the version in cabal file
* [X] Any changes that could be relevant to users have been recorded in the `CHANGELOG.md`
* [X] The documentation has been updated, if necessary.
* [X] Property tests or at least some unit test cases been added for all new functionality.
* [X] Link to any issues that might be related to this Pull Request.

Here is also a [great guide from Michael Snoyman](https://www.snoyman.com/blog/2017/06/how-to-send-me-a-pull-request) you can follow when submitting a PR that touches those packages.

Formatting recommendations:

* I personally use [hindent](https://www.stackage.org/package/hindent) on almost functions in the codebase, highly recommend it.
* [stylish-haskell](https://www.stackage.org/package/stylish-haskell) for organazing imports.
* If not using above formatting tools, please, just try to follow the general style present in the codebase: eg. 2 space indentation, no tabs, etc.
* Can't stand trailing whitespaces. If using `emacs`, there is `M-x delete-trailing-whitespace`.
