### PR TITLE
Redesign DL and other loaders to have access to efficient setting funtion

### DIFF
--- a/massiv-bench/bench/Concat.hs
+++ b/massiv-bench/bench/Concat.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Main where
+
+import Control.Scheduler
+import Criterion.Main
+import Data.Bifunctor
+import Data.Massiv.Array as A
+import Data.Massiv.Array.Unsafe as A
+import Data.Massiv.Bench.Common as A
+--import qualified Data.Vector.Primitive as VP
+import Control.DeepSeq
+import Control.Exception
+import Control.Monad as M
+import Data.Foldable as F
+import Data.List as L
+import Prelude as P
+import Data.Proxy
+
+main :: IO ()
+main = do
+  let !sz = Sz (600 :. 1000)
+  arrays :: [Matrix P Int] <- evaluate . force =<< M.replicateM 5 (makeRandomArray sz)
+  _vectors :: [Vector P Int] <- evaluate $ force $ P.map (resize' (Sz (totalElem sz))) arrays
+  defaultMain
+    [ bgroup
+        "Concat"
+        [ bench "concatM" $ whnf (computeAs P . concat' 2) arrays
+        , bench "concatMutableM" $
+          whnfIO (concatMutableM arrays :: IO (Matrix P Int))
+        , bench "concatMutableM DL" $
+          whnfIO (concatMutableM (P.map toLoadArray arrays) :: IO (Matrix P Int))
+        , bench "concatOuterM" $
+          whnf (computeAs P . throwEither . concatOuterM . P.map toLoadArray) arrays
+        , bench "concatNewM" $ whnfIO $ concatNewM arrays
+        --, bench "mconcat (DL)" $ whnf (A.computeAs P . mconcat . P.map toLoadArray) vectors
+        ]
+    ]
+
+concatMutableM ::
+     forall r' r ix e . (Load r' ix e, Mutable r ix e)
+  => [Array r' ix e]
+  -> IO (Array r ix e)
+concatMutableM arrsF =
+  case L.uncons arrsF of
+    Nothing -> pure empty
+    Just (a, arrs) -> do
+      let sz = unSz (size a)
+          szs = unSz . size <$> arrs
+          n = dimensions (Proxy :: Proxy ix)
+      (k, szl) <- pullOutDimM sz n
+      -- / remove the dimension out of all sizes along which concatenation will happen
+      (ks, szls) <-
+        F.foldrM (\ !csz (ks, szls) -> bimap (: ks) (: szls) <$> pullOutDimM csz n) ([], []) szs
+      -- / make sure to fail as soon as at least one of the arrays has a mismatching inner size
+      F.traverse_
+        (\(sz', _) -> throwM (SizeMismatchException (SafeSz sz) (SafeSz sz')))
+        (P.dropWhile ((== szl) . snd) $ P.zip szs szls)
+      let kTotal = SafeSz $ F.foldl' (+) k ks
+      newSz <- insertSzM (SafeSz szl) n kTotal
+      unsafeCreateArray_ (foldMap getComp arrsF) newSz $ \scheduler marr -> do
+        let arrayLoader !offset arr = do
+              scheduleWork scheduler $ do
+                loadArrayM scheduler arr (\i -> unsafeLinearWrite marr (i + offset))
+              pure (offset + totalElem (size arr))
+        foldM_ arrayLoader 0 $ a : arrs
+{-# INLINE concatMutableM #-}
+
+concatNewM ::
+     forall ix e r. (Index ix, Mutable r ix e)
+  => [Array r ix e]
+  -> IO (Array r ix e)
+concatNewM arrsF =
+  case L.uncons (F.toList arrsF) of
+    Nothing -> pure empty
+    Just (a, arrs) -> do
+      let sz = unSz (size a)
+          szs = unSz . size <$> arrs
+          n = dimensions (Proxy :: Proxy ix)
+      (k, szl) <- pullOutDimM sz n
+      -- / remove the dimension out of all sizes along which concatenation will happen
+      (ks, szls) <-
+        F.foldrM (\ !csz (ks, szls) -> bimap (: ks) (: szls) <$> pullOutDimM csz n) ([], []) szs
+      -- / make sure to fail as soon as at least one of the arrays has a mismatching inner size
+      F.traverse_
+        (\(sz', _) -> throwM (SizeMismatchException (SafeSz sz) (SafeSz sz')))
+        (P.dropWhile ((== szl) . snd) $ P.zip szs szls)
+      let kTotal = SafeSz $ F.foldl' (+) k ks
+      newSz <- insertSzM (SafeSz szl) n kTotal
+      unsafeCreateArray_ (foldMap getComp arrsF) newSz $ \scheduler marr -> do
+        let arrayLoader !kAcc (kCur, arr) = do
+              scheduleWork scheduler $
+                iforM_ arr $ \ix e ->
+                  let i = getDim' ix n
+                      ix' = setDim' ix n (i + kAcc)
+                   in unsafeLinearWrite marr (toLinearIndex newSz ix') e
+              pure (kAcc + kCur)
+        M.foldM_ arrayLoader 0 $ (k, a) : P.zip ks arrs
+{-# INLINE concatNewM #-}

--- a/massiv-bench/massiv-bench.cabal
+++ b/massiv-bench/massiv-bench.cabal
@@ -17,6 +17,7 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Data.Massiv.Bench
+                     , Data.Massiv.Bench.Common
                      , Data.Massiv.Bench.Sobel
                      , Data.Massiv.Bench.Matrix
                      , Data.Massiv.Bench.Vector
@@ -151,6 +152,20 @@ benchmark append
                      , massiv-bench
                      , vector
                      , dlist
+  default-language:    Haskell2010
+
+benchmark concat
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      bench
+  main-is:             Concat.hs
+  ghc-options:         -Wall -threaded -O2 -rtsopts -with-rtsopts=-N
+  build-depends:       base
+                     , criterion
+                     , deepseq
+                     , massiv
+                     , massiv-bench
+                     , scheduler
+                     , vector
   default-language:    Haskell2010
 
 benchmark filter

--- a/massiv-bench/src/Data/Massiv/Bench.hs
+++ b/massiv-bench/src/Data/Massiv/Bench.hs
@@ -1,8 +1,12 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
-module Data.Massiv.Bench where
+module Data.Massiv.Bench
+  ( module Data.Massiv.Bench
+  , module Data.Massiv.Bench.Common
+  ) where
 
 import Data.Massiv.Array
+import Data.Massiv.Bench.Common
 
 lightFunc :: Int -> Int -> Double
 lightFunc !i !j =
@@ -11,7 +15,7 @@ lightFunc !i !j =
 
 heavyFunc :: Int -> Int -> Double
 heavyFunc !i !j =
-  sin (sqrt (sqrt ((fromIntegral i) ** 2 + (fromIntegral j) ** 2)))
+  sin (sqrt (sqrt (fromIntegral i ** 2 + fromIntegral j ** 2)))
 {-# INLINE heavyFunc #-}
 
 lightFuncIx2 :: Ix2 -> Double

--- a/massiv-bench/src/Data/Massiv/Bench/Common.hs
+++ b/massiv-bench/src/Data/Massiv/Bench/Common.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Data.Massiv.Bench.Common
+  ( makeRandomArray
+  , showsType
+  , stdGen
+  ) where
+
+import Data.Massiv.Array
+import Data.Typeable
+import System.Random
+
+stdGen :: StdGen
+stdGen = mkStdGen 2020
+
+-- | Use Typeable to show the type.
+showsType :: forall t . Typeable t => ShowS
+showsType = showsTypeRep (typeRep (Proxy :: Proxy t))
+
+makeRandomArray :: (Mutable r ix e, Random e) => Sz ix -> IO (Array r ix e)
+makeRandomArray sz = do
+  gen <- newStdGen
+  pure $! snd $ randomArrayS gen sz random

--- a/massiv-bench/src/Data/Massiv/Bench/Matrix.hs
+++ b/massiv-bench/src/Data/Massiv/Bench/Matrix.hs
@@ -18,18 +18,12 @@ module Data.Massiv.Bench.Matrix
   , stdGen
   ) where
 
-import Data.Massiv.Array
-import Data.Typeable
-import Criterion.Main
-import System.Random
 import Control.DeepSeq
-
-stdGen :: StdGen
-stdGen = mkStdGen 2020
-
--- | Use Typeable to show the type.
-showsType :: forall t . Typeable t => ShowS
-showsType = showsTypeRep (typeRep (Proxy :: Proxy t))
+import Criterion.Main
+import Data.Massiv.Array
+import Data.Massiv.Bench.Common
+import Data.Typeable
+import System.Random
 
 aMxMsize :: Sz2
 aMxMsize = Sz2 500 800

--- a/massiv-bench/src/Data/Massiv/Bench/Vector.hs
+++ b/massiv-bench/src/Data/Massiv/Bench/Vector.hs
@@ -13,12 +13,13 @@ module Data.Massiv.Bench.Vector
   , showsType
   ) where
 
+import Control.DeepSeq
+import Criterion.Main
 import Data.Massiv.Array
+import Data.Massiv.Bench.Common
 import Data.Massiv.Bench.Matrix
 import Data.Typeable
-import Criterion.Main
 import System.Random
-import Control.DeepSeq
 
 v1size :: Sz1
 v1size = Sz1 1000000

--- a/massiv/CHANGELOG.md
+++ b/massiv/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.8
+
+* Improve loading of push arrays by adding `loadArrayWithSetM` and deprecating `defaultElement`.
+
 # 0.5.7
 
 * Improve performance of `><.` and `><!` while making their constraints a bit more relaxed.

--- a/massiv/massiv.cabal
+++ b/massiv/massiv.cabal
@@ -1,5 +1,5 @@
 name:                massiv
-version:             0.5.7.0
+version:             0.5.8.0
 synopsis:            Massiv (Массив) is an Array Library.
 description:         Multi-dimensional Arrays with fusion, stencils and parallel computation.
 homepage:            https://github.com/lehins/massiv

--- a/massiv/src/Data/Massiv/Array/Mutable.hs
+++ b/massiv/src/Data/Massiv/Array/Mutable.hs
@@ -251,10 +251,10 @@ freezeS smarr = do
 {-# INLINE freezeS #-}
 
 
-newMaybeInitialized ::
+unsafeNewUninitialized ::
      (Load r' ix e, Mutable r ix e, PrimMonad m) => Array r' ix e -> m (MArray (PrimState m) r ix e)
-newMaybeInitialized !arr = initializeNew (defaultElement arr) (fromMaybe zeroSz (maxSize arr))
-{-# INLINE newMaybeInitialized #-}
+unsafeNewUninitialized !arr = unsafeNew (fromMaybe zeroSz (maxSize arr))
+{-# INLINE unsafeNewUninitialized #-}
 
 
 -- | Load sequentially a pure array into the newly created mutable array.
@@ -265,7 +265,7 @@ loadArrayS ::
   => Array r' ix e
   -> m (MArray (PrimState m) r ix e)
 loadArrayS arr = do
-  marr <- newMaybeInitialized arr
+  marr <- unsafeNewUninitialized arr
   unsafeLoadIntoS marr arr
 {-# INLINE loadArrayS #-}
 
@@ -279,7 +279,7 @@ loadArray ::
   -> m (MArray RealWorld r ix e)
 loadArray arr =
   liftIO $ do
-    marr <- newMaybeInitialized arr
+    marr <- unsafeNewUninitialized arr
     unsafeLoadIntoM marr arr
 {-# INLINE loadArray #-}
 

--- a/massiv/src/Data/Massiv/Core.hs
+++ b/massiv/src/Data/Massiv/Core.hs
@@ -31,6 +31,8 @@ module Data.Massiv.Core
   , L(..)
   , LN
   , ListItem
+  , Scheduler
+  , SchedulerWS
   , Comp(Seq, Par, Par', ParOn, ParN)
   , WorkerStates
   , initWorkerStates
@@ -48,7 +50,7 @@ module Data.Massiv.Core
   , PrimMonad(PrimState)
   ) where
 
-import Control.Scheduler (initWorkerStates)
+import Control.Scheduler (SchedulerWS, initWorkerStates)
 import Data.Massiv.Core.Common
 import Data.Massiv.Core.Index
 import Data.Massiv.Core.List

--- a/massiv/src/Data/Massiv/Core/Index.hs
+++ b/massiv/src/Data/Massiv/Core/Index.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE BangPatterns    #-}
-{-# LANGUAGE DataKinds       #-}
-{-# LANGUAGE GADTs           #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE TypeOperators   #-}
+{-# LANGUAGE TypeOperators #-}
 -- |
 -- Module      : Data.Massiv.Core.Index
 -- Copyright   : (c) Alexey Kuleshevich 2018-2019
@@ -40,6 +40,7 @@ module Data.Massiv.Core.Index
   , setSzM
   , insertSzM
   , pullOutSzM
+  , toLinearSz
   -- ** Dimension
   , Dim(..)
   , Dimension(Dim1, Dim2, Dim3, Dim4, Dim5, DimN)
@@ -97,6 +98,7 @@ module Data.Massiv.Core.Index
 import Control.DeepSeq
 import Control.Exception (throw)
 import Control.Monad.Catch (MonadThrow(..))
+import Data.Coerce
 import Data.Functor.Identity (runIdentity)
 import Data.Massiv.Core.Exception (guardNumberOfElements)
 import Data.Massiv.Core.Index.Internal
@@ -224,6 +226,13 @@ isNonEmpty !sz = isSafeIndex sz zeroIndex
 -- - foldlIndex (*) 1 (unSz sz) /= 0
 -- - foldlIndex (\a x -> a && x /= 0) True (unSz sz)
 -- - totalElem sz == 0
+
+-- | Convert a size to a linear size.
+--
+-- @since 0.5.8
+toLinearSz :: Index ix => Sz ix -> Sz1
+toLinearSz = coerce . totalElem
+{-# INLINE [1] toLinearSz #-}
 
 -- | Get the outmost dimension of the index.
 --

--- a/massiv/src/Data/Massiv/Core/Index/Internal.hs
+++ b/massiv/src/Data/Massiv/Core/Index/Internal.hs
@@ -499,9 +499,8 @@ class ( Eq ix
   toLinearIndex ::
        Sz ix -- ^ Size
     -> ix -- ^ Index
-    -> Int
-  default toLinearIndex :: Index (Lower ix) =>
-    Sz ix -> ix -> Int
+    -> Ix1
+  default toLinearIndex :: Index (Lower ix) => Sz ix -> ix -> Ix1
   toLinearIndex (SafeSz sz) !ix = toLinearIndex (SafeSz szL) ixL * n + i
     where
       !(szL, n) = unsnocDim sz
@@ -512,9 +511,8 @@ class ( Eq ix
   -- likley be removed in future versions.
   --
   -- @since 0.1.0
-  toLinearIndexAcc :: Int -> ix -> ix -> Int
-  default toLinearIndexAcc :: Index (Lower ix) =>
-    Int -> ix -> ix -> Int
+  toLinearIndexAcc :: Ix1 -> ix -> ix -> Ix1
+  default toLinearIndexAcc :: Index (Lower ix) => Ix1 -> ix -> ix -> Ix1
   toLinearIndexAcc !acc !sz !ix = toLinearIndexAcc (acc * n + i) szL ixL
     where
       !(n, szL) = unconsDim sz
@@ -524,9 +522,8 @@ class ( Eq ix
   -- | Compute an index from size and linear index
   --
   -- @since 0.1.0
-  fromLinearIndex :: Sz ix -> Int -> ix
-  default fromLinearIndex :: Index (Lower ix) =>
-    Sz ix -> Int -> ix
+  fromLinearIndex :: Sz ix -> Ix1 -> ix
+  default fromLinearIndex :: Index (Lower ix) => Sz ix -> Ix1 -> ix
   fromLinearIndex (SafeSz sz) k = consDim q ixL
     where
       !(q, ixL) = fromLinearIndexAcc (snd (unconsDim sz)) k
@@ -536,9 +533,8 @@ class ( Eq ix
   -- tail recursion while getting the index computed.
   --
   -- @since 0.1.0
-  fromLinearIndexAcc :: ix -> Int -> (Int, ix)
-  default fromLinearIndexAcc :: Index (Lower ix) =>
-    ix -> Int -> (Int, ix)
+  fromLinearIndexAcc :: ix -> Ix1 -> (Int, ix)
+  default fromLinearIndexAcc :: Index (Lower ix) => ix -> Ix1 -> (Ix1, ix)
   fromLinearIndexAcc ix' !k = (q, consDim r ixL)
     where
       !(m, ix) = unconsDim ix'

--- a/massiv/src/Data/Massiv/Vector.hs
+++ b/massiv/src/Data/Massiv/Vector.hs
@@ -994,7 +994,8 @@ ssingleton = DSArray . S.singleton
 cons :: Load r Ix1 e => e -> Vector r e -> Vector DL e
 cons e v =
   let dv = toLoadArray v
-      load scheduler startAt uWrite = uWrite startAt e >> dlLoad dv scheduler (startAt + 1) uWrite
+      load scheduler startAt uWrite uSet =
+        uWrite startAt e >> dlLoad dv scheduler (startAt + 1) uWrite uSet
       {-# INLINE load #-}
    in dv {dlSize = SafeSz (1 + unSz (dlSize dv)), dlLoad = load}
 {-# INLINE cons #-}
@@ -1006,7 +1007,8 @@ snoc :: Load r Ix1 e => Vector r e -> e -> Vector DL e
 snoc v e =
   let dv = toLoadArray v
       !k = unSz (size dv)
-      load scheduler startAt uWrite = dlLoad dv scheduler startAt uWrite >> uWrite (k + startAt) e
+      load scheduler startAt uWrite uSet =
+        dlLoad dv scheduler startAt uWrite uSet >> uWrite (k + startAt) e
       {-# INLINE load #-}
    in dv {dlSize = SafeSz (1 + k), dlLoad = load}
 {-# INLINE snoc #-}


### PR DESCRIPTION
Performance of DL is still pretty bad, but at least I figured out why that is the case. RankN on `Monad m` in DL prevents all optimizations. Next version of massiv will have it switched to `ST` and performance of concat will be fixed at last

* Improve loading of push arrays by adding `loadArrayWithSetM` and
  deprecating `defaultElement`
* Export `Scheduler` and `SchedulerWS` from `Core`
* Add concat benchmarks