### PR TITLE
fix build with base >=4.18

### DIFF
--- a/massiv/src/Data/Massiv/Core/List.hs
+++ b/massiv/src/Data/Massiv/Core/List.hs
@@ -37,7 +37,7 @@ import Data.Massiv.Core.Common
 import qualified Data.Massiv.Vector.Stream as S
 import Data.Monoid
 import Data.Typeable
-import GHC.Exts
+import GHC.IsList
 import GHC.TypeLits
 import System.IO.Unsafe (unsafePerformIO)
 


### PR DESCRIPTION
Starting with version 4.18 base exports a `List` constructor from `GHC.Exts` (cf. https://hackage.haskell.org/package/base-4.18.0.0/docs/GHC-Exts.html#t:List), which clashes with `Data.Massiv.Core.List.List`.

By importing `IsList` via `GHC.IsList` in `Data.Massiv.Core.List` the conflict is avoided.