### PR TITLE
Disable Windows CI builds for LTS-12 and LTS-14

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -50,11 +50,11 @@ jobs:
             ghc: '9.6.5'
           - resolver: nightly
             ghc: '9.8.2'
-        # exclude:
-        #   - resolver: lts-12
-        #     os: windows-latest
-        #   - resolver: lts-14
-        #     os: windows-latest
+        exclude:
+          - resolver: lts-12 # Due to occasional: "permission denied (Access is denied.)"
+            os: windows-latest
+          - resolver: lts-14 # Due to occasional: "permission denied (Access is denied.)"
+            os: windows-latest
         #   # - resolver: lts-16
         #   #   os: windows-latest # OOM on building Test.Massiv.VectorSpec
         #   - resolver: lts-18


### PR DESCRIPTION
Tests of LTS-12 and LTS-14 on Windows occasionally fail with:
```
primitive                        > C:\Users\RUNNER~1\AppData\Local\Temp\ghc356D.c: DeleteFile "\\\\?\\C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\ghc356D.c": permission denied (Access is denied.)
```

or
```
doctest                          > C:\mingw64\bin\strip.exe: unable to copy file 'C:\sr\snapshots\10c94faf\bin\doctest.exe'; reason: Permission denied
```

This is a known problem for older ghc versions on Windows. We can just disable those.