### PR TITLE
Compatibility with GHC-9.12.1 and random-1.3.0

### DIFF
--- a/massiv/CHANGELOG.md
+++ b/massiv/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.4.1 
+
+* Added `deriving Generic` to `Ix2`, `IxN`, `Stride` and `Sz` types to ensure compatibility
+  with GHC 9.12.1 and random-1.3.
+
 # 1.0.4
 
 * Improve performance of sorting algorithm and its parallelization. Fix huge slow down on

--- a/massiv/massiv.cabal
+++ b/massiv/massiv.cabal
@@ -1,5 +1,5 @@
 name:                massiv
-version:             1.0.4.0
+version:             1.0.4.1
 synopsis:            Massiv (Массив) is an Array Library.
 description:         Multi-dimensional Arrays with fusion, stencils and parallel computation.
 homepage:            https://github.com/lehins/massiv
@@ -24,6 +24,7 @@ tested-with:         GHC == 8.0.2
                    , GHC == 9.4.8
                    , GHC == 9.6.5
                    , GHC == 9.8.2
+                   , GHC == 9.12.1
 
 flag unsafe-checks
   description: Enable all the bounds checks for unsafe functions at the cost of

--- a/massiv/src/Data/Massiv/Core/Index/Internal.hs
+++ b/massiv/src/Data/Massiv/Core/Index/Internal.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 
 -- |
@@ -74,6 +75,7 @@ import Data.Kind
 import Data.Massiv.Core.Loop
 import Data.Typeable
 import GHC.TypeLits
+import GHC.Generics
 import System.Random.Stateful
 
 -- | `Sz` is the size of the array. It describes total number of elements along
@@ -113,7 +115,7 @@ newtype Sz ix
     --
     -- @since 0.3.0
     SafeSz ix
-  deriving (Eq, Ord, NFData)
+  deriving (Eq, Ord, NFData, Generic)
 
 -- | A safe bidirectional pattern synonym for `Sz` construction that will make sure that none of
 -- the size elements are negative.
@@ -135,6 +137,7 @@ pattern Sz1 ix <- SafeSz ix
     Sz1 ix = SafeSz (max 0 ix)
 
 {-# COMPLETE Sz1 #-}
+
 
 instance (UniformRange ix, Index ix) => Uniform (Sz ix) where
   uniformM g = SafeSz <$> uniformRM (pureIndex 0, pureIndex maxBound) g
@@ -355,7 +358,7 @@ pullOutSzM (SafeSz sz) = fmap coerce . pullOutDimM sz
 -- | A way to select Array dimension at a value level.
 --
 -- @since 0.1.0
-newtype Dim = Dim {unDim :: Int} deriving (Eq, Ord, Num, Real, Integral, Enum, NFData)
+newtype Dim = Dim {unDim :: Int} deriving (Eq, Ord, Num, Real, Integral, Enum, NFData, Generic)
 
 instance Show Dim where
   show (Dim d) = "(Dim " ++ show d ++ ")"

--- a/massiv/src/Data/Massiv/Core/Index/Ix.hs
+++ b/massiv/src/Data/Massiv/Core/Index/Ix.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 -- |
 -- Module      : Data.Massiv.Core.Index.Ix
@@ -50,6 +51,7 @@ import qualified Data.Vector.Generic.Mutable as VM
 import qualified Data.Vector.Unboxed as VU
 import qualified GHC.Arr as I
 import GHC.TypeLits
+import GHC.Generics 
 import System.Random.Stateful
 #if !MIN_VERSION_base(4,11,0)
 import Data.Semigroup
@@ -60,7 +62,7 @@ infixr 5 :>, :.
 -- | 2-dimensional index. This is also a base index for higher dimensions.
 --
 -- @since 0.1.0
-data Ix2 = {-# UNPACK #-} !Int :. {-# UNPACK #-} !Int
+data Ix2 = {-# UNPACK #-} !Int :. {-# UNPACK #-} !Int deriving Generic
 
 -- | 2-dimensional index constructor. Useful when infix notation is inconvenient. @(Ix2 i j) == (i :. j)@
 --
@@ -145,7 +147,7 @@ pattern Sz5 i5 i4 i3 i2 i1 = Sz (i5 :> i4 :> i3 :> i2 :. i1)
 -- | n-dimensional index. Needs a base case, which is the `Ix2`.
 --
 -- @since 0.1.0
-data IxN (n :: Nat) = {-# UNPACK #-} !Int :> !(Ix (n - 1))
+data IxN (n :: Nat) = {-# UNPACK #-} !Int :> !(Ix (n - 1)) deriving Generic
 
 -- | Defines n-dimensional index by relating a general `IxN` with few base cases.
 --

--- a/massiv/src/Data/Massiv/Core/Index/Stride.hs
+++ b/massiv/src/Data/Massiv/Core/Index/Stride.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 -- |
 -- Module      : Data.Massiv.Core.Index.Stride
@@ -22,6 +23,7 @@ module Data.Massiv.Core.Index.Stride (
 import Control.DeepSeq (NFData)
 import Data.Massiv.Core.Index.Internal
 import System.Random.Stateful (Random, Uniform (..), UniformRange (..))
+import GHC.Generics 
 
 -- | Stride provides a way to ignore elements of an array if an index is divisible by a
 -- corresponding value in a stride. So, for a @Stride (i :. j)@ only elements with indices will be
@@ -49,7 +51,7 @@ import System.Random.Stateful (Random, Uniform (..), UniformRange (..))
 --   column intact then you'd use @Stride (5 :. 1)@.
 --
 -- @since 0.2.1
-newtype Stride ix = SafeStride ix deriving (Eq, Ord, NFData)
+newtype Stride ix = SafeStride ix deriving (Eq, Ord, NFData, Generic)
 
 -- | A safe bidirectional pattern synonym for `Stride` construction that will make sure stride
 -- elements are always positive.


### PR DESCRIPTION
I have added `deriving Generic` directives to `Ix2`, `IxN`, `Stride`, `Sz` types to be able to compile with GHC 9.12.1 and random-1.3 

Please include this checklist whenever changes are introduced to `massiv` package:

* [ ] Bump up the version in cabal file, when applicable.
* [X] Any changes that could be relevant to users have been recorded in the `CHANGELOG.md`
* [ ] The documentation has been updated, if necessary.
* [ ] Property tests or at least some unit test cases been added for all new functionality.
* [ ] Linked issues that might be related to this Pull Request.

Formatting recommendations:

* I personally use [fourmolu](https://github.com/fourmolu/fourmolu) for this repo and the [`fourmolu.yaml`](https://github.com/lehins/massiv/blob/master/fourmolu.yaml) config is included at the top level

Here is also a [great guide from Michael Snoyman](https://www.snoyman.com/blog/2017/06/how-to-send-me-a-pull-request) you can follow when submitting a PR that touches those packages.

