### PR TITLE
Improve performance of `DWArray`

### DIFF
--- a/massiv-test/tests/Test/Massiv/Array/StencilSpec.hs
+++ b/massiv-test/tests/Test/Massiv/Array/StencilSpec.hs
@@ -92,7 +92,7 @@ unsafeMapStencil
   -> Array DW ix a
 unsafeMapStencil b sSz sCenter stencilF !arr = insertWindow warr window
   where
-    !warr = makeArray (getComp arr) sz (stencil (borderIndex b arr))
+    !warr = makeArrayR D (getComp arr) sz (stencil (borderIndex b arr))
     !window =
       Window
         { windowStart = sCenter

--- a/massiv/CHANGELOG.md
+++ b/massiv/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.5
+
+* Improve performance and reduce allocations during computation of higher dimension `DW` arrays [#142](https://github.com/lehins/massiv/issues/142)
+
 # 1.0.4
 
 * Improve performance of sorting algorithm and its parallelization. Fix huge slow down on

--- a/massiv/massiv.cabal
+++ b/massiv/massiv.cabal
@@ -1,5 +1,5 @@
 name:                massiv
-version:             1.0.4.1
+version:             1.0.5.0
 synopsis:            Massiv (Массив) is an Array Library.
 description:         Multi-dimensional Arrays with fusion, stencils and parallel computation.
 homepage:            https://github.com/lehins/massiv

--- a/massiv/src/Data/Massiv/Array/Delayed/Windowed.hs
+++ b/massiv/src/Data/Massiv/Array/Delayed/Windowed.hs
@@ -11,7 +11,7 @@
 
 -- |
 -- Module      : Data.Massiv.Array.Delayed.Windowed
--- Copyright   : (c) Alexey Kuleshevich 2018-2022
+-- Copyright   : (c) Alexey Kuleshevich 2018-2025
 -- License     : BSD3
 -- Maintainer  : Alexey Kuleshevich <lehins@yandex.ru>
 -- Stability   : experimental
@@ -27,6 +27,7 @@ module Data.Massiv.Array.Delayed.Windowed (
 ) where
 
 import Control.Monad (when)
+import Control.Scheduler (trivialScheduler_)
 import Data.Massiv.Array.Delayed.Pull
 import Data.Massiv.Array.Manifest.Boxed
 import Data.Massiv.Array.Manifest.Internal
@@ -58,7 +59,7 @@ instance Functor (Window ix) where
 data instance Array DW ix e = DWArray
   { dwComp :: !Comp
   , dwSize :: !(Sz ix)
-  , dwIndex :: !(ix -> e)
+  , dwIndex :: ix -> e
   , dwWindow :: !(Maybe (Window ix e))
   }
 
@@ -132,7 +133,7 @@ makeWindowedArray
   -- ^ Indexing function foto use inside window
   -> Array DW ix e
 makeWindowedArray !arr wStart wSize wIndex =
-  insertWindow arr $
+  insertWindow (delay arr) $
     Window{windowStart = wStart, windowSize = wSize, windowIndex = wIndex, windowUnrollIx2 = Nothing}
 {-# INLINE makeWindowedArray #-}
 
@@ -141,8 +142,8 @@ makeWindowedArray !arr wStart wSize wIndex =
 --
 -- @since 0.3.0
 insertWindow
-  :: (Index ix, Source r e)
-  => Array r ix e
+  :: (Index ix)
+  => Array D ix e
   -- ^ Source array that will have a window inserted into it
   -> Window ix e
   -- ^ Window to place inside the delayed array
@@ -381,42 +382,47 @@ loadArrayWithIxN
 loadArrayWithIxN scheduler stride szResult arr uWrite = do
   let DWArray _ sz uIndex window = arr
       Window{windowStart, windowSize, windowIndex, windowUnrollIx2} = fromMaybe zeroWindow window
-      !(headSourceSize, lowerSourceSize) = unconsSz sz
+      !(!headSourceSize, !lowerSourceSize) = unconsSz sz
       !lowerSize = snd $ unconsSz szResult
-      !(s, lowerStrideIx) = unconsDim $ unStride stride
-      !(curWindowStart, lowerWindowStart) = unconsDim windowStart
-      !(headWindowSz, tailWindowSz) = unconsSz windowSize
+      !(!s, !lowerStrideIx) = unconsDim $ unStride stride
+      !(!curWindowStart, lowerWindowStart) = unconsDim windowStart
+      !(!headWindowSz, tailWindowSz) = unconsSz windowSize
       !curWindowEnd = curWindowStart + unSz headWindowSz
       !pageElements = totalElem lowerSize
-      mkLowerWindow i =
+      lowerWindow =
         Window
           { windowStart = lowerWindowStart
           , windowSize = tailWindowSz
-          , windowIndex = windowIndex . consDim i
+          , windowIndex = \_ -> error "Window index uninitialized"
           , windowUnrollIx2 = windowUnrollIx2
           }
-      mkLowerArray mw i =
-        DWArray
-          { dwComp = Seq
-          , dwSize = lowerSourceSize
-          , dwIndex = uIndex . consDim i
-          , dwWindow = ($ i) <$> mw
+      mkLowerWindow !i =
+        lowerWindow
+          { windowIndex = windowIndex . consDim i
           }
-      loadLower mw !i =
-        iterArrayLinearWithStrideST_
-          scheduler
-          (Stride lowerStrideIx)
-          lowerSize
-          (mkLowerArray mw i)
-          (\k -> uWrite (k + pageElements * (i `div` s)))
-      {-# NOINLINE loadLower #-}
-  loopA_ 0 (< headDim windowStart) (+ s) (loadLower Nothing)
+      loadLower mkWindow !i =
+        let !lowerArray =
+               DWArray
+                 { dwComp = Seq
+                 , dwSize = lowerSourceSize
+                 , dwIndex = uIndex . consDim i
+                 , dwWindow = mkWindow i
+                 }
+            !innerScheduler =
+              if numWorkers scheduler <= unSz (strideSize (Stride s) headSourceSize)
+                then trivialScheduler_
+                else scheduler
+        in scheduleWork_ scheduler $
+             iterArrayLinearWithStrideST_ innerScheduler (Stride lowerStrideIx) lowerSize lowerArray $ \k ->
+               uWrite (k + pageElements * (i `div` s))
+      {-# INLINE loadLower #-}
+  loopA_ 0 (< headDim windowStart) (+ s) (loadLower (const Nothing))
   loopA_
     (strideStart (Stride s) curWindowStart)
     (< curWindowEnd)
     (+ s)
-    (loadLower (Just mkLowerWindow))
-  loopA_ (strideStart (Stride s) curWindowEnd) (< unSz headSourceSize) (+ s) (loadLower Nothing)
+    (loadLower (Just . mkLowerWindow))
+  loopA_ (strideStart (Stride s) curWindowEnd) (< unSz headSourceSize) (+ s) (loadLower (const Nothing))
 {-# INLINE loadArrayWithIxN #-}
 
 loadWithIxN
@@ -428,31 +434,39 @@ loadWithIxN
 loadWithIxN scheduler arr uWrite = do
   let DWArray _ sz uIndex window = arr
       Window{windowStart, windowSize, windowIndex, windowUnrollIx2} = fromMaybe zeroWindow window
-      !(si, szL) = unconsSz sz
+      !(!si, !szL) = unconsSz sz
       !windowEnd = liftIndex2 (+) windowStart (unSz windowSize)
-      !(t, windowStartL) = unconsDim windowStart
+      !(!t, windowStartL) = unconsDim windowStart
       !pageElements = totalElem szL
-      mkLowerWindow i =
+      lowerWindow =
         Window
           { windowStart = windowStartL
           , windowSize = snd $ unconsSz windowSize
-          , windowIndex = windowIndex . consDim i
+          , windowIndex = \_ -> error "Window index uninitialized"
           , windowUnrollIx2 = windowUnrollIx2
           }
-      mkLowerArray mw i =
-        DWArray
-          { dwComp = Seq
-          , dwSize = szL
-          , dwIndex = uIndex . consDim i
-          , dwWindow = ($ i) <$> mw
+      mkLowerWindow !i =
+        lowerWindow
+          { windowIndex = windowIndex . consDim i
           }
-      loadLower mw !i =
-        scheduleWork_ scheduler $
-          iterArrayLinearST_ scheduler (mkLowerArray mw i) (\k -> uWrite (k + pageElements * i))
-      {-# NOINLINE loadLower #-}
-  loopA_ 0 (< headDim windowStart) (+ 1) (loadLower Nothing)
-  loopA_ t (< headDim windowEnd) (+ 1) (loadLower (Just mkLowerWindow))
-  loopA_ (headDim windowEnd) (< unSz si) (+ 1) (loadLower Nothing)
+      loadLower mkWindow !i =
+        let !lowerArray =
+              DWArray
+                { dwComp = Seq
+                , dwSize = szL
+                , dwIndex = uIndex . consDim i
+                , dwWindow = mkWindow i
+                }
+            !innerScheduler =
+              if numWorkers scheduler <= unSz si
+                then trivialScheduler_
+                else scheduler
+         in scheduleWork_ scheduler $
+              iterArrayLinearST_ innerScheduler lowerArray (\k -> uWrite (k + pageElements * i))
+      {-# INLINE loadLower #-}
+  loopA_ 0 (< headDim windowStart) (+ 1) (loadLower (const Nothing))
+  loopA_ t (< headDim windowEnd) (+ 1) (loadLower (Just . mkLowerWindow))
+  loopA_ (headDim windowEnd) (< unSz si) (+ 1) (loadLower (const Nothing))
 {-# INLINE loadWithIxN #-}
 
 unrollAndJam


### PR DESCRIPTION
This PR removed layer of indirection by inlining definition of `D` arrays into `DW` array, while avoiding need for `PrefIndex`, since `DW` arrays always deal with multi-dimensional indexing and supporting linear indexing not only is unnecessary, but it also comes with slight extra overhead.

Improve parallelization of higher dimensional DW arrays and reduce memory overhead required for computation with the help of some inlining.

Addresses part of #142

Please include this checklist whenever changes are introduced to `massiv` package:

* [x] Bump up the version in cabal file, when applicable.
* [x] Any changes that could be relevant to users have been recorded in the `CHANGELOG.md`
* [ ] The documentation has been updated, if necessary.
* [ ] Property tests or at least some unit test cases been added for all new functionality.
* [x] Linked issues that might be related to this Pull Request.

Formatting recommendations:

* I personally use [fourmolu](https://github.com/fourmolu/fourmolu) for this repo and the [`fourmolu.yaml`](https://github.com/lehins/massiv/blob/master/fourmolu.yaml) config is included at the top level

Here is also a [great guide from Michael Snoyman](https://www.snoyman.com/blog/2017/06/how-to-send-me-a-pull-request) you can follow when submitting a PR that touches those packages.

